### PR TITLE
Fix + refactor tests for PopulateFilesProperty

### DIFF
--- a/main.go
+++ b/main.go
@@ -18,7 +18,10 @@ func PrepareImport() (string, error) {
 type FileProperty map[string][]string
 
 func PopulateFilesProperty(filenames []string) FileProperty {
-	fileProperty := FileProperty{}
+	fileProperty := FileProperty{
+		// "effectif": []string{"coucou"},
+		// "debit":    []string{},
+	}
 	for _, filename := range filenames {
 		filetype, _ := GetFileType(filename)
 		if _, exists := fileProperty[filetype]; !exists {

--- a/main.go
+++ b/main.go
@@ -3,9 +3,11 @@
 
 package main
 
-import ("errors")
+import (
+	"errors"
+)
 
-func main(){
+func main() {
 }
 
 func PrepareImport() (string, error) {
@@ -16,26 +18,26 @@ func PrepareImport() (string, error) {
 type FileProperty map[string][]string
 
 func PopulateFilesProperty(filenames []string) FileProperty {
-  fileProperty := FileProperty{}
-  for _, filename := range filenames {
+	fileProperty := FileProperty{}
+	for _, filename := range filenames {
 		filetype, _ := GetFileType(filename)
 		if _, exists := fileProperty[filetype]; !exists {
 			fileProperty[filetype] = []string{}
 		}
-    fileProperty[filetype] = append(fileProperty[filetype], filename)
-  }
-  return fileProperty
+		fileProperty[filetype] = append(fileProperty[filetype], filename)
+	}
+	return fileProperty
 }
 
 func GetFileType(filename string) (string, error) {
 	switch filename {
 	case "Sigfaibles_effectif_siret.csv":
-    return "effectif", nil
+		return "effectif", nil
 	case "Sigfaibles_debits.csv":
-    return "debit", nil
+		return "debit", nil
 	case "Sigfaibles_debits2.csv":
-    return "debit", nil
+		return "debit", nil
 	default:
-    return "", errors.New("Unrecognized type for " + filename)
+		return "", errors.New("Unrecognized type for " + filename)
 	}
 }

--- a/main_test.go
+++ b/main_test.go
@@ -23,25 +23,42 @@ func serializeSlice(stringsSlice []string) string {
 }
 
 func TestPopulateFilesProperty(t *testing.T) {
-	var filesProperty FileProperty
-	filesProperty = PopulateFilesProperty([]string{"Sigfaibles_effectif_siret.csv"})
-	if filesProperty["effectif"][0] != "Sigfaibles_effectif_siret.csv" {
-		t.Error("PopulateFilesProperty should contain effectif file in \"effectif\" property")
-	}
 
-	filesProperty = PopulateFilesProperty([]string{"Sigfaibles_debits.csv"})
-	_, ok := filesProperty["debit"]
-	if !ok || filesProperty["debit"][0] != "Sigfaibles_debits.csv" {
-		t.Error("PopulateFilesProperty should contain one debit file in \"debit\" property")
-	}
+	/**
+	 * TIL: t.Run() can be used to define sub-tests. (see https://golang.org/pkg/testing/#hdr-Subtests_and_Sub_benchmarks)
+	 *
+	 * Here's what is logged by `$ go test` if the first t.Run() block fails:
+	 *
+	 * --- FAIL: TestPopulateFilesProperty (0.00s)
+	 *     --- FAIL: TestPopulateFilesProperty/PopulateFilesProperty_should_contain_effectif_file_in_"effectif"_property (0.00s)
+	 *         main_test.go:31: PopulateFilesProperty should contain effectif file in "effectif" property
+	 */
 
-	filesProperty = PopulateFilesProperty([]string{"Sigfaibles_debits.csv", "Sigfaibles_debits2.csv"})
-	_, ok = filesProperty["debit"]
-	if !ok ||
-		filesProperty["debit"][0] != "Sigfaibles_debits.csv" ||
-		filesProperty["debit"][1] != "Sigfaibles_debits2.csv" {
-		t.Error("PopulateFilesProperty should contain both debits files in \"debit\" property")
-	}
+	t.Run("PopulateFilesProperty should contain effectif file in \"effectif\" property", func(t *testing.T) {
+		var filesProperty FileProperty
+		filesProperty = PopulateFilesProperty([]string{"Sigfaibles_effectif_siret.csv"})
+		if filesProperty["effectif"][0] != "Sigfaibles_effectif_siret.csv" {
+			t.Error("PopulateFilesProperty should contain effectif file in \"effectif\" property")
+		}
+	})
+
+	t.Run("PopulateFilesProperty should contain one debit file in \"debit\" property", func(t *testing.T) {
+		filesProperty := PopulateFilesProperty([]string{"Sigfaibles_debits.csv"})
+		_, ok := filesProperty["debit"]
+		if !ok || filesProperty["debit"][0] != "Sigfaibles_debits.csv" {
+			t.Error("PopulateFilesProperty should contain one debit file in \"debit\" property")
+		}
+	})
+
+	t.Run("PopulateFilesProperty should contain both debits files in \"debit\" property", func(t *testing.T) {
+		filesProperty := PopulateFilesProperty([]string{"Sigfaibles_debits.csv", "Sigfaibles_debits2.csv"})
+		_, ok := filesProperty["debit"]
+		if !ok ||
+			filesProperty["debit"][0] != "Sigfaibles_debits.csv" ||
+			filesProperty["debit"][1] != "Sigfaibles_debits2.csv" {
+			t.Error("PopulateFilesProperty should contain both debits files in \"debit\" property")
+		}
+	})
 }
 
 func TestGetFileType(t *testing.T) {

--- a/main_test.go
+++ b/main_test.go
@@ -2,57 +2,59 @@
 
 package main
 
-import ("testing"; "sort")
+import (
+	"sort"
+	"testing"
+)
 
 // Prepare import should return json object.
-func TestPrepareImport(t *testing.T){
-  res, _ := PrepareImport()
-  if (res != "{}") {
-    t.Error("Test failed: invalid json")
-  }
+func TestPrepareImport(t *testing.T) {
+	res, _ := PrepareImport()
+	if res != "{}" {
+		t.Error("Test failed: invalid json")
+	}
 }
 
 func serializeSlice(strings []string) string {
-  return strings.Join(sort.Strings(strings)[:], ",")
+	return strings.Join(sort.Strings(strings)[:], ",")
 }
 
-func TestPopulateFilesProperty(t *testing.T){
-  var filesProperty FileProperty
-  filesProperty = PopulateFilesProperty([]string{"Sigfaibles_effectif_siret.csv"})
-  if (filesProperty["effectif"][0] != "Sigfaibles_effectif_siret.csv") {
-    t.Error("PopulateFilesProperty should contain effectif file in \"effectif\" property")
+func TestPopulateFilesProperty(t *testing.T) {
+	var filesProperty FileProperty
+	filesProperty = PopulateFilesProperty([]string{"Sigfaibles_effectif_siret.csv"})
+	if filesProperty["effectif"][0] != "Sigfaibles_effectif_siret.csv" {
+		t.Error("PopulateFilesProperty should contain effectif file in \"effectif\" property")
 	}
-// strings.Join(reg[:],",")
-// sort.Strings(
-
+	// strings.Join(reg[:],",")
+	// sort.Strings(
 
 	filesProperty = PopulateFilesProperty([]string{"Sigfaibles_debits.csv"})
 	_, ok := filesProperty["debit"]
-  if (!ok || filesProperty["debit"][0] != "Sigfaibles_debits.csv") {
-    t.Error("PopulateFilesProperty should contain one debit file in \"debit\" property")
+	if !ok || filesProperty["debit"][0] != "Sigfaibles_debits.csv" {
+		t.Error("PopulateFilesProperty should contain one debit file in \"debit\" property")
 	}
 
 	filesProperty = PopulateFilesProperty([]string{"Sigfaibles_debits.csv", "Sigfaibles_debits2.csv"})
 	_, ok = filesProperty["debit"]
-	if (!ok ||
+	if !ok ||
 		filesProperty["debit"][0] != "Sigfaibles_debits.csv" ||
-		filesProperty["debit"][1] != "Sigfaibles_debits2.csv") {
-    t.Error("PopulateFilesProperty should contain both debits files in \"debit\" property")
+		filesProperty["debit"][1] != "Sigfaibles_debits2.csv" {
+		t.Error("PopulateFilesProperty should contain both debits files in \"debit\" property")
 	}
 }
 
-func TestGetFileType(t *testing.T){
+func TestGetFileType(t *testing.T) {
 	res1, _ := GetFileType("Sigfaibles_effectif_siret.csv")
-	if (res1 != "effectif") {
+	if res1 != "effectif" {
 		t.Error("GetFileType should return \"effectif\" for \"Sigfaibles_effectif_siret.csv\"")
 	}
 	res2, _ := GetFileType("Sigfaibles_debits.csv")
-  if (res2 != "debit") {
-    t.Error("GetFileType should return \"debit\" for \"Sigfaibles_debits.csv\"")
-  }
+	if res2 != "debit" {
+		t.Error("GetFileType should return \"debit\" for \"Sigfaibles_debits.csv\"")
+	}
 
-  res3, _ := GetFileType("Sigfaibles_debits2.csv")
-  if (res3 != "debit") {
-    t.Error("GetFileType should return \"debit\" for \"Sigfaibles_debits2.csv\"")
-  }
+	res3, _ := GetFileType("Sigfaibles_debits2.csv")
+	if res3 != "debit" {
+		t.Error("GetFileType should return \"debit\" for \"Sigfaibles_debits2.csv\"")
+	}
 }

--- a/main_test.go
+++ b/main_test.go
@@ -16,6 +16,7 @@ func TestPrepareImport(t *testing.T) {
 	}
 }
 
+// To make slices of strings comparable.
 func serializeSlice(stringsSlice []string) string {
 	stringsClone := append(stringsSlice[:0:0], stringsSlice...)
 	sort.Strings(stringsClone)
@@ -32,45 +33,30 @@ func isEqual(t *testing.T, got, want string) {
 	}
 }
 
-// This function checks that a map's property is a slice of the expected length.
-func hasPropOfLength(t *testing.T, filesProperty FileProperty, propKey string, expectedLength int) {
+func isEqualSlice(t *testing.T, got, want []string) {
 	t.Helper()
-	if propValue, propExists := filesProperty[propKey]; !propExists {
-		t.Errorf("filesProperty should have a %q property", propKey)
-	} else if len(propValue) != expectedLength {
-		t.Errorf("filesProperty value has length %v instead of %v", len(propValue), expectedLength)
+	if serializeSlice(got) != serializeSlice(want) {
+		t.Errorf("got %q instead of %q", got, want)
 	}
 }
 
 func TestPopulateFilesProperty(t *testing.T) {
 
-	/**
-	 * t.Run() can be used to define sub-tests. (see https://golang.org/pkg/testing/#hdr-Subtests_and_Sub_benchmarks)
-	 *
-	 * Here's what is logged by `$ go test` if the first t.Run() block fails:
-	 *
-	 * --- FAIL: TestPopulateFilesProperty (0.00s)
-	 *     --- FAIL: TestPopulateFilesProperty/PopulateFilesProperty_should_contain_effectif_file_in_"effectif"_property (0.00s)
-	 *         main_test.go:31: PopulateFilesProperty should contain effectif file in "effectif" property
-	 */
+	// t.Run() is used to define sub-tests. (see https://golang.org/pkg/testing/#hdr-Subtests_and_Sub_benchmarks)
 
 	t.Run("PopulateFilesProperty should contain effectif file in \"effectif\" property", func(t *testing.T) {
 		filesProperty := PopulateFilesProperty([]string{"Sigfaibles_effectif_siret.csv"})
-		hasPropOfLength(t, filesProperty, "effectif", 1)
-		isEqual(t, filesProperty["effectif"][0], "Sigfaibles_effectif_siret.csv")
+		isEqualSlice(t, filesProperty["effectif"], []string{"Sigfaibles_effectif_siret.csv"})
 	})
 
 	t.Run("PopulateFilesProperty should contain one debit file in \"debit\" property", func(t *testing.T) {
 		filesProperty := PopulateFilesProperty([]string{"Sigfaibles_debits.csv"})
-		hasPropOfLength(t, filesProperty, "debit", 1)
-		isEqual(t, filesProperty["debit"][0], "Sigfaibles_debits.csv")
+		isEqualSlice(t, filesProperty["debit"], []string{"Sigfaibles_debits.csv"})
 	})
 
 	t.Run("PopulateFilesProperty should contain both debits files in \"debit\" property", func(t *testing.T) {
 		filesProperty := PopulateFilesProperty([]string{"Sigfaibles_debits.csv", "Sigfaibles_debits2.csv"})
-		hasPropOfLength(t, filesProperty, "debit", 2)
-		isEqual(t, filesProperty["debit"][0], "Sigfaibles_debits.csv")
-		isEqual(t, filesProperty["debit"][1], "Sigfaibles_debits2.csv")
+		isEqualSlice(t, filesProperty["debit"], []string{"Sigfaibles_debits.csv", "Sigfaibles_debits2.csv"})
 	})
 }
 

--- a/main_test.go
+++ b/main_test.go
@@ -22,10 +22,20 @@ func serializeSlice(stringsSlice []string) string {
 	return strings.Join(stringsClone, ",")
 }
 
+// This function can be used to reduce duplication of assertions,
+// while explaining why a failing tests did fail.
+// (see `assertCorrectMessage` from https://github.com/quii/learn-go-with-tests/blob/master/hello-world.md#hello-world-again)
+func isEqual(t *testing.T, got, want string) {
+	t.Helper()
+	if got != want {
+		t.Errorf("got %q instead of %q", got, want)
+	}
+}
+
 func TestPopulateFilesProperty(t *testing.T) {
 
 	/**
-	 * TIL: t.Run() can be used to define sub-tests. (see https://golang.org/pkg/testing/#hdr-Subtests_and_Sub_benchmarks)
+	 * t.Run() can be used to define sub-tests. (see https://golang.org/pkg/testing/#hdr-Subtests_and_Sub_benchmarks)
 	 *
 	 * Here's what is logged by `$ go test` if the first t.Run() block fails:
 	 *
@@ -35,29 +45,28 @@ func TestPopulateFilesProperty(t *testing.T) {
 	 */
 
 	t.Run("PopulateFilesProperty should contain effectif file in \"effectif\" property", func(t *testing.T) {
-		var filesProperty FileProperty
-		filesProperty = PopulateFilesProperty([]string{"Sigfaibles_effectif_siret.csv"})
-		if filesProperty["effectif"][0] != "Sigfaibles_effectif_siret.csv" {
-			t.Error("PopulateFilesProperty should contain effectif file in \"effectif\" property")
+		filesProperty := PopulateFilesProperty([]string{"Sigfaibles_effectif_siret.csv"})
+		if _, ok := filesProperty["effectif"]; !ok {
+			t.Error("PopulateFilesProperty should have a \"effectif\" property")
 		}
+		isEqual(t, filesProperty["effectif"][0], "Sigfaibles_effectif_siret.csv")
 	})
 
 	t.Run("PopulateFilesProperty should contain one debit file in \"debit\" property", func(t *testing.T) {
 		filesProperty := PopulateFilesProperty([]string{"Sigfaibles_debits.csv"})
-		_, ok := filesProperty["debit"]
-		if !ok || filesProperty["debit"][0] != "Sigfaibles_debits.csv" {
-			t.Error("PopulateFilesProperty should contain one debit file in \"debit\" property")
+		if _, ok := filesProperty["debit"]; !ok {
+			t.Error("PopulateFilesProperty should have a \"debit\" property")
 		}
+		isEqual(t, filesProperty["debit"][0], "Sigfaibles_debits.csv")
 	})
 
 	t.Run("PopulateFilesProperty should contain both debits files in \"debit\" property", func(t *testing.T) {
 		filesProperty := PopulateFilesProperty([]string{"Sigfaibles_debits.csv", "Sigfaibles_debits2.csv"})
-		_, ok := filesProperty["debit"]
-		if !ok ||
-			filesProperty["debit"][0] != "Sigfaibles_debits.csv" ||
-			filesProperty["debit"][1] != "Sigfaibles_debits2.csv" {
-			t.Error("PopulateFilesProperty should contain both debits files in \"debit\" property")
+		if _, ok := filesProperty["debit"]; !ok {
+			t.Error("PopulateFilesProperty should have a \"debit\" property")
 		}
+		isEqual(t, filesProperty["debit"][0], "Sigfaibles_debits.csv")
+		isEqual(t, filesProperty["debit"][1], "Sigfaibles_debits2.csv")
 	})
 }
 

--- a/main_test.go
+++ b/main_test.go
@@ -32,6 +32,16 @@ func isEqual(t *testing.T, got, want string) {
 	}
 }
 
+// This function checks that a map's property is a slice of the expected length.
+func hasPropOfLength(t *testing.T, filesProperty FileProperty, propKey string, expectedLength int) {
+	t.Helper()
+	if propValue, propExists := filesProperty[propKey]; !propExists {
+		t.Errorf("filesProperty should have a %q property", propKey)
+	} else if len(propValue) != expectedLength {
+		t.Errorf("filesProperty value has length %v instead of %v", len(propValue), expectedLength)
+	}
+}
+
 func TestPopulateFilesProperty(t *testing.T) {
 
 	/**
@@ -46,25 +56,19 @@ func TestPopulateFilesProperty(t *testing.T) {
 
 	t.Run("PopulateFilesProperty should contain effectif file in \"effectif\" property", func(t *testing.T) {
 		filesProperty := PopulateFilesProperty([]string{"Sigfaibles_effectif_siret.csv"})
-		if _, ok := filesProperty["effectif"]; !ok {
-			t.Error("PopulateFilesProperty should have a \"effectif\" property")
-		}
+		hasPropOfLength(t, filesProperty, "effectif", 1)
 		isEqual(t, filesProperty["effectif"][0], "Sigfaibles_effectif_siret.csv")
 	})
 
 	t.Run("PopulateFilesProperty should contain one debit file in \"debit\" property", func(t *testing.T) {
 		filesProperty := PopulateFilesProperty([]string{"Sigfaibles_debits.csv"})
-		if _, ok := filesProperty["debit"]; !ok {
-			t.Error("PopulateFilesProperty should have a \"debit\" property")
-		}
+		hasPropOfLength(t, filesProperty, "debit", 1)
 		isEqual(t, filesProperty["debit"][0], "Sigfaibles_debits.csv")
 	})
 
 	t.Run("PopulateFilesProperty should contain both debits files in \"debit\" property", func(t *testing.T) {
 		filesProperty := PopulateFilesProperty([]string{"Sigfaibles_debits.csv", "Sigfaibles_debits2.csv"})
-		if _, ok := filesProperty["debit"]; !ok {
-			t.Error("PopulateFilesProperty should have a \"debit\" property")
-		}
+		hasPropOfLength(t, filesProperty, "debit", 2)
 		isEqual(t, filesProperty["debit"][0], "Sigfaibles_debits.csv")
 		isEqual(t, filesProperty["debit"][1], "Sigfaibles_debits2.csv")
 	})

--- a/main_test.go
+++ b/main_test.go
@@ -4,6 +4,7 @@ package main
 
 import (
 	"sort"
+	"strings"
 	"testing"
 )
 
@@ -15,8 +16,10 @@ func TestPrepareImport(t *testing.T) {
 	}
 }
 
-func serializeSlice(strings []string) string {
-	return strings.Join(sort.Strings(strings)[:], ",")
+func serializeSlice(stringsSlice []string) string {
+	stringsClone := append(stringsSlice[:0:0], stringsSlice...)
+	sort.Strings(stringsClone)
+	return strings.Join(stringsClone, ",")
 }
 
 func TestPopulateFilesProperty(t *testing.T) {
@@ -25,8 +28,6 @@ func TestPopulateFilesProperty(t *testing.T) {
 	if filesProperty["effectif"][0] != "Sigfaibles_effectif_siret.csv" {
 		t.Error("PopulateFilesProperty should contain effectif file in \"effectif\" property")
 	}
-	// strings.Join(reg[:],",")
-	// sort.Strings(
 
 	filesProperty = PopulateFilesProperty([]string{"Sigfaibles_debits.csv"})
 	_, ok := filesProperty["debit"]


### PR DESCRIPTION
...following this morning's pairing session.

See the list of commits to see the steps I followed.

My intent was to make it possible and easy to review the diff of each step individually.

Review recommendation: As I reformatted the code (thanks to a plug-in for my IDE that runs `gofmt` every time I save a go file), feel free to ignore the resulting diff by disabling the whitespace diff, from GitHub's PR interface.

![image](https://user-images.githubusercontent.com/531781/77546537-4ccaa280-6eac-11ea-97cf-0238676bf4eb.png)

Possible next steps:

- See "Table-driven tests using subtests" from [Using Subtests and Sub-benchmarks - The Go Blog](https://blog.golang.org/subtests)
- Use `assert` helpers provided by [stretchr/testify: A toolkit with common assertions and mocks that plays nicely with the standard library](https://github.com/stretchr/testify/#assert-package) (recommended by Anthony Seure)