### PR TITLE
Feat: Prendre en charge fichiers csv courants

### DIFF
--- a/main.go
+++ b/main.go
@@ -83,6 +83,8 @@ func GetFileType(filename string) string {
 		return "filter"
 	case filename == "sireneUL.csv":
 		return "sirene_ul"
+	case filename == "StockEtablissement_utf8_geo.csv":
+		return "comptes"
 	case filename == "Sigfaibles_debits.csv":
 		return "debit"
 	case filename == "Sigfaibles_debits2.csv":

--- a/main.go
+++ b/main.go
@@ -69,13 +69,14 @@ func PopulateFilesProperty(filenames []string) FilesProperty {
 }
 
 var hasDianePrefix = regexp.MustCompile(`^diane`)
+var mentionsEffectif = regexp.MustCompile(`effectif_`)
 
 // GetFileType returns a file type from filename, or empty string for unsupported file names
 func GetFileType(filename string) string {
 	switch {
 	case hasDianePrefix.MatchString(filename):
 		return "diane"
-	case filename == "Sigfaibles_effectif_siret.csv":
+	case mentionsEffectif.MatchString(filename):
 		return "effectif"
 	case filename == "Sigfaibles_debits.csv":
 		return "debit"

--- a/main.go
+++ b/main.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"log"
+	"regexp"
 )
 
 func main() {
@@ -67,14 +68,18 @@ func PopulateFilesProperty(filenames []string) FilesProperty {
 	return filesProperty
 }
 
+var hasDianePrefix = regexp.MustCompile(`^diane`)
+
 // GetFileType returns a file type from filename, or empty string for unsupported file names
 func GetFileType(filename string) string {
-	switch filename {
-	case "Sigfaibles_effectif_siret.csv":
+	switch {
+	case hasDianePrefix.MatchString(filename):
+		return "diane"
+	case filename == "Sigfaibles_effectif_siret.csv":
 		return "effectif"
-	case "Sigfaibles_debits.csv":
+	case filename == "Sigfaibles_debits.csv":
 		return "debit"
-	case "Sigfaibles_debits2.csv":
+	case filename == "Sigfaibles_debits2.csv":
 		return "debit"
 	default:
 		return ""

--- a/main.go
+++ b/main.go
@@ -81,6 +81,8 @@ func GetFileType(filename string) string {
 		return "effectif"
 	case hasFilterPrefix.MatchString(filename):
 		return "filter"
+	case filename == "sireneUL.csv":
+		return "sirene_ul"
 	case filename == "Sigfaibles_debits.csv":
 		return "debit"
 	case filename == "Sigfaibles_debits2.csv":

--- a/main.go
+++ b/main.go
@@ -75,12 +75,6 @@ var hasFilterPrefix = regexp.MustCompile(`^filter_`)
 // GetFileType returns a file type from filename, or empty string for unsupported file names
 func GetFileType(filename string) string {
 	switch {
-	case hasDianePrefix.MatchString(filename):
-		return "diane"
-	case mentionsEffectif.MatchString(filename):
-		return "effectif"
-	case hasFilterPrefix.MatchString(filename):
-		return "filter"
 	case filename == "sireneUL.csv":
 		return "sirene_ul"
 	case filename == "StockEtablissement_utf8_geo.csv":
@@ -89,6 +83,12 @@ func GetFileType(filename string) string {
 		return "debit"
 	case filename == "Sigfaibles_debits2.csv":
 		return "debit"
+	case hasDianePrefix.MatchString(filename):
+		return "diane"
+	case mentionsEffectif.MatchString(filename):
+		return "effectif"
+	case hasFilterPrefix.MatchString(filename):
+		return "filter"
 	default:
 		return ""
 	}

--- a/main.go
+++ b/main.go
@@ -70,6 +70,7 @@ func PopulateFilesProperty(filenames []string) FilesProperty {
 
 var hasDianePrefix = regexp.MustCompile(`^diane`)
 var mentionsEffectif = regexp.MustCompile(`effectif_`)
+var hasFilterPrefix = regexp.MustCompile(`^filter_`)
 
 // GetFileType returns a file type from filename, or empty string for unsupported file names
 func GetFileType(filename string) string {
@@ -78,6 +79,8 @@ func GetFileType(filename string) string {
 		return "diane"
 	case mentionsEffectif.MatchString(filename):
 		return "effectif"
+	case hasFilterPrefix.MatchString(filename):
+		return "filter"
 	case filename == "Sigfaibles_debits.csv":
 		return "debit"
 	case filename == "Sigfaibles_debits2.csv":

--- a/main_test.go
+++ b/main_test.go
@@ -63,27 +63,23 @@ func TestPurePrepareImport(t *testing.T) {
 		assert.Equal(t, AdminObject{"files": FilesProperty{}}, res)
 	})
 
-	/*
-		t.Run("Should support usual csv files", func(t *testing.T) {
-			files := []string{
-				// "Sigfaibles_effectif_siret.csv",
-				// "Sigfaibles_debits.csv",
-				"diane_req_2002.csv",              // --> "diane"
-				"diane_req_dom_2002.csv",          // --> "diane"
-				"effectif_dom.csv",                // --> "effectif"
-				"filter_siren_2002.csv",           // --> "filter"
-				"sireneUL.csv",                    // --> "sirene_ul"
-				"StockEtablissement_utf8_geo.csv", // --> "comptes"
-			}
-			res := PurePrepareImport(files)
-			resFilesProperty := res["files"].(FilesProperty)
-			resultingFiles := []string{}
-			for _, filenames := range resFilesProperty {
-				resultingFiles = append(resultingFiles, filenames...)
-			}
-			assert.Equal(t, files, resultingFiles)
-		})
-	*/
+	t.Run("Should support multiple types of csv files", func(t *testing.T) {
+		files := []string{
+			"diane_req_2002.csv",              // --> "diane"
+			"diane_req_dom_2002.csv",          // --> "diane"
+			"effectif_dom.csv",                // --> "effectif"
+			"filter_siren_2002.csv",           // --> "filter"
+			"sireneUL.csv",                    // --> "sirene_ul"
+			"StockEtablissement_utf8_geo.csv", // --> "comptes"
+		}
+		res := PurePrepareImport(files)
+		resFilesProperty := res["files"].(FilesProperty)
+		resultingFiles := []string{}
+		for _, filenames := range resFilesProperty {
+			resultingFiles = append(resultingFiles, filenames...)
+		}
+		assert.Equal(t, files, resultingFiles)
+	})
 }
 
 func TestPopulateFilesProperty(t *testing.T) {

--- a/main_test.go
+++ b/main_test.go
@@ -63,26 +63,27 @@ func TestPurePrepareImport(t *testing.T) {
 		assert.Equal(t, AdminObject{"files": FilesProperty{}}, res)
 	})
 
-	t.Run("Should support usual csv files", func(t *testing.T) {
-		files := []string{
-			// "Sigfaibles_effectif_siret.csv",
-			// "Sigfaibles_debits.csv",
-			"diane_req_2002.csv",
-			"diane_req_dom_2002.csv",
-			"effectif_dom.csv",
-			"filter_siren_2002.csv",
-			"sireneUL.csv",
-			"StockEtablissement_utf8_geo.csv",
-		}
-		res := PurePrepareImport(files)
-		resFilesProperty := res["files"].(FilesProperty)
-		resultingFiles := []string{}
-		for _, filenames := range resFilesProperty {
-			resultingFiles = append(resultingFiles, filenames...)
-		}
-		assert.Equal(t, files, resultingFiles)
-	})
-
+	/*
+		t.Run("Should support usual csv files", func(t *testing.T) {
+			files := []string{
+				// "Sigfaibles_effectif_siret.csv",
+				// "Sigfaibles_debits.csv",
+				"diane_req_2002.csv",              // --> "diane"
+				"diane_req_dom_2002.csv",          // --> "diane"
+				"effectif_dom.csv",                // --> "effectif"
+				"filter_siren_2002.csv",           // --> "filter"
+				"sireneUL.csv",                    // --> "sirene_ul"
+				"StockEtablissement_utf8_geo.csv", // --> "comptes"
+			}
+			res := PurePrepareImport(files)
+			resFilesProperty := res["files"].(FilesProperty)
+			resultingFiles := []string{}
+			for _, filenames := range resFilesProperty {
+				resultingFiles = append(resultingFiles, filenames...)
+			}
+			assert.Equal(t, files, resultingFiles)
+		})
+	*/
 }
 
 func TestPopulateFilesProperty(t *testing.T) {
@@ -121,4 +122,23 @@ func TestGetFileType(t *testing.T) {
 		got := GetFileType("Sigfaibles_debits2.csv")
 		assert.Equal(t, "debit", got)
 	})
+
+	// inspired by https://github.com/golang/go/wiki/TableDrivenTests
+	cases := []struct {
+		name     string
+		category string
+	}{
+		{"diane_req_2002.csv", "diane"},
+		// {"diane_req_dom_2002.csv", "diane"},
+		// {"effectif_dom.csv", "effectif"},
+		// {"filter_siren_2002.csv", "filter"},
+		// {"sireneUL.csv", "sirene_ul"},
+		// {"StockEtablissement_utf8_geo.csv", "comptes"},
+	}
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			got := GetFileType(testCase.name)
+			assert.Equal(t, testCase.category, got)
+		})
+	}
 }

--- a/main_test.go
+++ b/main_test.go
@@ -130,7 +130,7 @@ func TestGetFileType(t *testing.T) {
 	}{
 		{"diane_req_2002.csv", "diane"},
 		{"diane_req_dom_2002.csv", "diane"},
-		// {"effectif_dom.csv", "effectif"},
+		{"effectif_dom.csv", "effectif"},
 		// {"filter_siren_2002.csv", "filter"},
 		// {"sireneUL.csv", "sirene_ul"},
 		// {"StockEtablissement_utf8_geo.csv", "comptes"},

--- a/main_test.go
+++ b/main_test.go
@@ -1,5 +1,3 @@
-// $ go test # to run the tests
-
 package main
 
 import (
@@ -10,14 +8,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 )
-
-// func TestMain(t *testing.T) {
-// 	t.Run("Should return a files property from a directory name", func(t *testing.T) {
-// 		res := main()
-// 		expected := "{\"files\": {\"debit\": [\"Sigfaibles_debits.csv\"]}}"
-// 		t.Equal(t, expected, res)
-// 	})
-// }
 
 func createTempFiles(t *testing.T, filename string) string {
 	t.Helper()
@@ -74,12 +64,8 @@ func TestPurePrepareImport(t *testing.T) {
 }
 
 func TestPopulateFilesProperty(t *testing.T) {
-
-	// t.Run() is used to define sub-tests. (see https://golang.org/pkg/testing/#hdr-Subtests_and_Sub_benchmarks)
-
 	t.Run("PopulateFilesProperty should contain effectif file in \"effectif\" property", func(t *testing.T) {
 		filesProperty := PopulateFilesProperty([]string{"Sigfaibles_effectif_siret.csv"})
-		// isEqualSlice(t, filesProperty["effectif"], []string{"Sigfaibles_effectif_siret.csv"})
 		assert.Equal(t, []string{"Sigfaibles_effectif_siret.csv"}, filesProperty["effectif"])
 	})
 

--- a/main_test.go
+++ b/main_test.go
@@ -129,7 +129,7 @@ func TestGetFileType(t *testing.T) {
 		category string
 	}{
 		{"diane_req_2002.csv", "diane"},
-		// {"diane_req_dom_2002.csv", "diane"},
+		{"diane_req_dom_2002.csv", "diane"},
 		// {"effectif_dom.csv", "effectif"},
 		// {"filter_siren_2002.csv", "filter"},
 		// {"sireneUL.csv", "sirene_ul"},

--- a/main_test.go
+++ b/main_test.go
@@ -132,7 +132,7 @@ func TestGetFileType(t *testing.T) {
 		{"diane_req_dom_2002.csv", "diane"},
 		{"effectif_dom.csv", "effectif"},
 		{"filter_siren_2002.csv", "filter"},
-		// {"sireneUL.csv", "sirene_ul"},
+		{"sireneUL.csv", "sirene_ul"},
 		// {"StockEtablissement_utf8_geo.csv", "comptes"},
 	}
 	for _, testCase := range cases {

--- a/main_test.go
+++ b/main_test.go
@@ -133,7 +133,7 @@ func TestGetFileType(t *testing.T) {
 		{"effectif_dom.csv", "effectif"},
 		{"filter_siren_2002.csv", "filter"},
 		{"sireneUL.csv", "sirene_ul"},
-		// {"StockEtablissement_utf8_geo.csv", "comptes"},
+		{"StockEtablissement_utf8_geo.csv", "comptes"},
 	}
 	for _, testCase := range cases {
 		t.Run("should return "+testCase.category+" for file "+testCase.name, func(t *testing.T) {

--- a/main_test.go
+++ b/main_test.go
@@ -136,7 +136,7 @@ func TestGetFileType(t *testing.T) {
 		// {"StockEtablissement_utf8_geo.csv", "comptes"},
 	}
 	for _, testCase := range cases {
-		t.Run(testCase.name, func(t *testing.T) {
+		t.Run("should return "+testCase.category+" for file "+testCase.name, func(t *testing.T) {
 			got := GetFileType(testCase.name)
 			assert.Equal(t, testCase.category, got)
 		})

--- a/main_test.go
+++ b/main_test.go
@@ -131,7 +131,7 @@ func TestGetFileType(t *testing.T) {
 		{"diane_req_2002.csv", "diane"},
 		{"diane_req_dom_2002.csv", "diane"},
 		{"effectif_dom.csv", "effectif"},
-		// {"filter_siren_2002.csv", "filter"},
+		{"filter_siren_2002.csv", "filter"},
 		// {"sireneUL.csv", "sirene_ul"},
 		// {"StockEtablissement_utf8_geo.csv", "comptes"},
 	}

--- a/main_test.go
+++ b/main_test.go
@@ -78,7 +78,7 @@ func TestPurePrepareImport(t *testing.T) {
 		for _, filenames := range resFilesProperty {
 			resultingFiles = append(resultingFiles, filenames...)
 		}
-		assert.Equal(t, files, resultingFiles)
+		assert.Subset(t, resultingFiles, files)
 	})
 }
 

--- a/main_test.go
+++ b/main_test.go
@@ -57,10 +57,32 @@ func TestPurePrepareImport(t *testing.T) {
 		}
 		assert.Equal(t, expected, res)
 	})
+
 	t.Run("Should return an empty json when there is no file", func(t *testing.T) {
 		res := PurePrepareImport([]string{})
 		assert.Equal(t, AdminObject{"files": FilesProperty{}}, res)
 	})
+
+	t.Run("Should support usual csv files", func(t *testing.T) {
+		files := []string{
+			// "Sigfaibles_effectif_siret.csv",
+			// "Sigfaibles_debits.csv",
+			"diane_req_2002.csv",
+			"diane_req_dom_2002.csv",
+			"effectif_dom.csv",
+			"filter_siren_2002.csv",
+			"sireneUL.csv",
+			"StockEtablissement_utf8_geo.csv",
+		}
+		res := PurePrepareImport(files)
+		resFilesProperty := res["files"].(FilesProperty)
+		resultingFiles := []string{}
+		for _, filenames := range resFilesProperty {
+			resultingFiles = append(resultingFiles, filenames...)
+		}
+		assert.Equal(t, files, resultingFiles)
+	})
+
 }
 
 func TestPopulateFilesProperty(t *testing.T) {


### PR DESCRIPTION
Ajoute le support de plusieurs fichiers de données réels:

```
			"diane_req_2002.csv",              // --> "diane"
			"diane_req_dom_2002.csv",          // --> "diane"
			"effectif_dom.csv",                // --> "effectif"
			"filter_siren_2002.csv",           // --> "filter"
			"sireneUL.csv",                    // --> "sirene_ul"
			"StockEtablissement_utf8_geo.csv", // --> "comptes"
```

Et intègre une nouvelle manière de définir des tests: table-based.