### PR TITLE
feat: Reconnaissance de certains fichiers reçus par goup

### DIFF
--- a/main.go
+++ b/main.go
@@ -89,6 +89,10 @@ func GetFileType(filename string, getFileMeta func(string) UploadedFileMeta) str
 			return "bdf"
 		}
 		return GetFileType(metadata["filename"], DefaultMetadataReader)
+	case filename == "act_partielle_conso_depuis2014_FRANCE.csv":
+		return "apconso"
+	case filename == "act_partielle_ddes_depuis2015_FRANCE.csv":
+		return "apdemande"
 	case filename == "Sigfaible_pcoll.csv":
 		return "procol"
 	case filename == "Sigfaible_cotisdues.csv":

--- a/main.go
+++ b/main.go
@@ -87,7 +87,7 @@ func GetFileType(filename string, getFileMeta func(string) UploadedFileMeta) str
 		metadata := getFileMeta(filename)["MetaData"].(map[string]string)
 		return GetFileType(metadata["filename"], DefaultMetadataReader)
 	case filename == "Sigfaible_cotisdues.csv":
-		return "urssaf"
+		return "cotisation"
 	case filename == "sireneUL.csv":
 		return "sirene_ul"
 	case filename == "StockEtablissement_utf8_geo.csv":

--- a/main.go
+++ b/main.go
@@ -105,6 +105,8 @@ func GetFileType(filename string, getFileMeta func(string) UploadedFileMeta) str
 		return "sirene_ul"
 	case filename == "StockEtablissement_utf8_geo.csv":
 		return "comptes"
+	case strings.HasSuffix(filename, ".sas7bdat"):
+		return "interim"
 	case mentionsDebits.MatchString(filename):
 		return "debit"
 	case hasDianePrefix.MatchString(filename):

--- a/main.go
+++ b/main.go
@@ -51,7 +51,7 @@ func ReadFilenames(path string) ([]string, error) {
 type FilesProperty map[string][]string
 
 func DefaultMetadataReader(filename string) UploadedFileMeta {
-	return UploadedFileMeta{}
+	return UploadedFileMeta{} // TODO: if filename is a bin file, we should return the metadata from the corresponding info file
 }
 
 func PopulateFilesProperty(filenames []string) FilesProperty {

--- a/main.go
+++ b/main.go
@@ -51,7 +51,7 @@ func ReadFilenames(path string) ([]string, error) {
 type FilesProperty map[string][]string
 
 func DefaultMetadataReader(filename string) UploadedFileMeta {
-	return UploadedFileMeta{} // TODO
+	return UploadedFileMeta{}
 }
 
 func PopulateFilesProperty(filenames []string) FilesProperty {

--- a/main.go
+++ b/main.go
@@ -85,6 +85,9 @@ func GetFileType(filename string, getFileMeta func(string) UploadedFileMeta) str
 	switch {
 	case strings.HasSuffix(filename, ".bin"):
 		metadata := getFileMeta(filename)["MetaData"].(map[string]string)
+		if metadata["goup-path"] == "bdf" {
+			return "entreprise"
+		}
 		return GetFileType(metadata["filename"], DefaultMetadataReader)
 	case filename == "Sigfaible_pcoll.csv":
 		return "procol"

--- a/main.go
+++ b/main.go
@@ -75,6 +75,7 @@ func PopulateFilesProperty(filenames []string) FilesProperty {
 
 var hasDianePrefix = regexp.MustCompile(`^diane`)
 var mentionsEffectif = regexp.MustCompile(`effectif_`)
+var mentionsDebits = regexp.MustCompile(`_debits`)
 var hasFilterPrefix = regexp.MustCompile(`^filter_`)
 
 type UploadedFileMeta map[string]interface{}
@@ -84,14 +85,14 @@ func GetFileType(filename string, getFileMeta func(string) UploadedFileMeta) str
 	switch {
 	case strings.HasSuffix(filename, ".bin"):
 		metadata := getFileMeta(filename)["MetaData"].(map[string]string)
-		return metadata["goup-path"] // e.g. "urssaf"
+		return GetFileType(metadata["filename"], DefaultMetadataReader)
+	case filename == "Sigfaible_cotisdues.csv":
+		return "urssaf"
 	case filename == "sireneUL.csv":
 		return "sirene_ul"
 	case filename == "StockEtablissement_utf8_geo.csv":
 		return "comptes"
-	case filename == "Sigfaibles_debits.csv":
-		return "debit"
-	case filename == "Sigfaibles_debits2.csv":
+	case mentionsDebits.MatchString(filename):
 		return "debit"
 	case hasDianePrefix.MatchString(filename):
 		return "diane"

--- a/main.go
+++ b/main.go
@@ -86,8 +86,14 @@ func GetFileType(filename string, getFileMeta func(string) UploadedFileMeta) str
 	case strings.HasSuffix(filename, ".bin"):
 		metadata := getFileMeta(filename)["MetaData"].(map[string]string)
 		return GetFileType(metadata["filename"], DefaultMetadataReader)
+	case filename == "Sigfaible_pcoll.csv":
+		return "procol"
 	case filename == "Sigfaible_cotisdues.csv":
 		return "cotisation"
+	case filename == "Sigfaible_delais.csv":
+		return "delai"
+	case filename == "Sigfaible_ccsf.csv":
+		return "ccsf"
 	case filename == "sireneUL.csv":
 		return "sirene_ul"
 	case filename == "StockEtablissement_utf8_geo.csv":

--- a/main.go
+++ b/main.go
@@ -86,7 +86,7 @@ func GetFileType(filename string, getFileMeta func(string) UploadedFileMeta) str
 	case strings.HasSuffix(filename, ".bin"):
 		metadata := getFileMeta(filename)["MetaData"].(map[string]string)
 		if metadata["goup-path"] == "bdf" {
-			return "entreprise"
+			return "bdf"
 		}
 		return GetFileType(metadata["filename"], DefaultMetadataReader)
 	case filename == "Sigfaible_pcoll.csv":

--- a/main_test.go
+++ b/main_test.go
@@ -120,14 +120,12 @@ func TestGetFileType(t *testing.T) {
 		assert.Equal(t, "debit", got)
 	})
 
-	t.Run("should return \"cotisation\" for bin file which come from urssaf", func(t *testing.T) {
+	t.Run("should return \"cotisation\" for bin file which original name included \"cotisdues\"", func(t *testing.T) {
 		got := GetFileType("15b6ceeb928a3bc160b0e2dc2a794ad4.bin", func(filename string) UploadedFileMeta {
 			return UploadedFileMeta{
 				"MetaData": map[string]string{
 					"filename":  "Sigfaible_cotisdues.csv",
-					"filetype":  "application/vnd.ms-excel",
 					"goup-path": "urssaf",
-					"private":   "false",
 				},
 			}
 		})
@@ -135,13 +133,11 @@ func TestGetFileType(t *testing.T) {
 	})
 
 	t.Run("should return \"debit\" for bin file which original name included \"debits\"", func(t *testing.T) {
-		got := GetFileType("15b6ceeb928a3bc160b0e2dc2a794ad4.bin", func(filename string) UploadedFileMeta {
+		got := GetFileType("9a047825d8173684b69994428449302f.bin", func(filename string) UploadedFileMeta {
 			return UploadedFileMeta{
 				"MetaData": map[string]string{
 					"filename":  "Sigfaible_debits.csv",
-					"filetype":  "application/vnd.ms-excel",
 					"goup-path": "urssaf",
-					"private":   "false",
 				},
 			}
 		})

--- a/main_test.go
+++ b/main_test.go
@@ -120,12 +120,12 @@ func TestGetFileType(t *testing.T) {
 		assert.Equal(t, "debit", got)
 	})
 
-	t.Run("should return \"entreprise\" for bin file which came from bdf", func(t *testing.T) {
+	t.Run("should return \"bdf\" for bin file which came from bdf", func(t *testing.T) {
 		got := GetFileType("60d1bd320523904d8b8b427efbbd3928.bin", MakeMetadataReader(map[string]string{
 			"filename":  "FICHIER_SF_2020_02.csv",
 			"goup-path": "bdf",
 		}))
-		assert.Equal(t, "entreprise", got)
+		assert.Equal(t, "bdf", got)
 	})
 
 	// inspired by https://github.com/golang/go/wiki/TableDrivenTests

--- a/main_test.go
+++ b/main_test.go
@@ -119,6 +119,21 @@ func TestGetFileType(t *testing.T) {
 		assert.Equal(t, "debit", got)
 	})
 
+	t.Run("should return \"urssaf\" for bin file which come from urssaf", func(t *testing.T) {
+		type UploadedFileMeta map[string]interface{}
+		got := GetFileType("15b6ceeb928a3bc160b0e2dc2a794ad4.bin", func(filename string) UploadedFileMeta {
+			return UploadedFileMeta{
+				"MetaData": map[string]string{
+					"filename":  "Sigfaible_cotisdues.csv",
+					"filetype":  "application/vnd.ms-excel",
+					"goup-path": "urssaf",
+					"private":   "false",
+				},
+			}
+		})
+		assert.Equal(t, "urssaf", got)
+	})
+
 	// inspired by https://github.com/golang/go/wiki/TableDrivenTests
 	cases := []struct {
 		name     string

--- a/main_test.go
+++ b/main_test.go
@@ -120,6 +120,14 @@ func TestGetFileType(t *testing.T) {
 		assert.Equal(t, "debit", got)
 	})
 
+	t.Run("should return \"entreprise\" for bin file which came from bdf", func(t *testing.T) {
+		got := GetFileType("60d1bd320523904d8b8b427efbbd3928.bin", MakeMetadataReader(map[string]string{
+			"filename":  "FICHIER_SF_2020_02.csv",
+			"goup-path": "bdf",
+		}))
+		assert.Equal(t, "entreprise", got)
+	})
+
 	// inspired by https://github.com/golang/go/wiki/TableDrivenTests
 	cases := []struct {
 		name     string

--- a/main_test.go
+++ b/main_test.go
@@ -97,6 +97,7 @@ func TestPopulateFilesProperty(t *testing.T) {
 		filesProperty := PopulateFilesProperty([]string{"Sigfaibles_debits.csv", "Sigfaibles_debits2.csv"})
 		assert.Equal(t, []string{"Sigfaibles_debits.csv", "Sigfaibles_debits2.csv"}, filesProperty["debit"])
 	})
+
 	t.Run("Should not include unsupported files", func(t *testing.T) {
 		filesProperty := PopulateFilesProperty([]string{"coco.csv"})
 		assert.Equal(t, FilesProperty{}, filesProperty)
@@ -105,22 +106,21 @@ func TestPopulateFilesProperty(t *testing.T) {
 
 func TestGetFileType(t *testing.T) {
 	t.Run("should return \"effectif\" for \"Sigfaibles_effectif_siret.csv\"", func(t *testing.T) {
-		got := GetFileType("Sigfaibles_effectif_siret.csv")
+		got := GetFileType("Sigfaibles_effectif_siret.csv", DefaultMetadataReader)
 		assert.Equal(t, "effectif", got)
 	})
 
 	t.Run("should return \"debit\" for \"Sigfaibles_debits.csv\"", func(t *testing.T) {
-		got := GetFileType("Sigfaibles_debits.csv")
+		got := GetFileType("Sigfaibles_debits.csv", DefaultMetadataReader)
 		assert.Equal(t, "debit", got)
 	})
 
 	t.Run("should return \"debit\" for \"Sigfaibles_debits2.csv\"", func(t *testing.T) {
-		got := GetFileType("Sigfaibles_debits2.csv")
+		got := GetFileType("Sigfaibles_debits2.csv", DefaultMetadataReader)
 		assert.Equal(t, "debit", got)
 	})
 
 	t.Run("should return \"urssaf\" for bin file which come from urssaf", func(t *testing.T) {
-		type UploadedFileMeta map[string]interface{}
 		got := GetFileType("15b6ceeb928a3bc160b0e2dc2a794ad4.bin", func(filename string) UploadedFileMeta {
 			return UploadedFileMeta{
 				"MetaData": map[string]string{
@@ -148,7 +148,7 @@ func TestGetFileType(t *testing.T) {
 	}
 	for _, testCase := range cases {
 		t.Run("should return "+testCase.category+" for file "+testCase.name, func(t *testing.T) {
-			got := GetFileType(testCase.name)
+			got := GetFileType(testCase.name, DefaultMetadataReader)
 			assert.Equal(t, testCase.category, got)
 		})
 	}

--- a/main_test.go
+++ b/main_test.go
@@ -130,8 +130,8 @@ func TestGetFileType(t *testing.T) {
 		{"Sigfaible_cotisdues.csv", "cotisation"},
 		{"Sigfaible_pcoll.csv", "procol"},
 		// {"Sigfaible_etablissement_utf8.csv", "admin_urssaf"}, // to be confirmed
-		{"Sigfaible_effectif_siret.csv.csv", "effectif"},     // to be confirmed
-		{"Sigfaible_effectif_siren.csv.csv", "effectif"},     // to be confirmed
+		{"Sigfaible_effectif_siret.csv.csv", "effectif"}, // to be confirmed
+		{"Sigfaible_effectif_siren.csv.csv", "effectif"}, // to be confirmed
 		{"Sigfaible_delais.csv", "delai"},
 		{"Sigfaible_ccsf.csv", "ccsf"},
 		// {"xx.csv", "dpae"}, // Déclaration préalable à l'embauche => TODO: filename?

--- a/main_test.go
+++ b/main_test.go
@@ -125,10 +125,21 @@ func TestGetFileType(t *testing.T) {
 		name     string
 		category string
 	}{
-		{"Sigfaibles_effectif_siret.csv", "effectif"},
+		// guessed from urssaf files found on stockage/goub server
+		{"Sigfaible_debits.csv", "debit"},
+		{"Sigfaible_cotisdues.csv", "cotisation"},
+		{"Sigfaible_pcoll.csv", "procol"},
+		// {"Sigfaible_etablissement_utf8.csv", "admin_urssaf"}, // to be confirmed
+		{"Sigfaible_effectif_siret.csv.csv", "effectif"},     // to be confirmed
+		{"Sigfaible_effectif_siren.csv.csv", "effectif"},     // to be confirmed
+		{"Sigfaible_delais.csv", "delai"},
+		{"Sigfaible_ccsf.csv", "ccsf"},
+		// {"xx.csv", "dpae"}, // Déclaration préalable à l'embauche => TODO: filename?
+		// {"xx.csv", "dmmo"}, // Déclaration annuelle des mouvements de main-d'œuvre => TODO: filename?
+
+		// others
 		{"Sigfaibles_debits.csv", "debit"},
 		{"Sigfaibles_debits2.csv", "debit"},
-		{"Sigfaible_cotisdues.csv", "cotisation"},
 		{"diane_req_2002.csv", "diane"},
 		{"diane_req_dom_2002.csv", "diane"},
 		{"effectif_dom.csv", "effectif"},

--- a/main_test.go
+++ b/main_test.go
@@ -111,28 +111,6 @@ func MakeMetadataReader(metadataFields map[string]string) func(string) UploadedF
 }
 
 func TestGetFileType(t *testing.T) {
-	t.Run("should return \"effectif\" for \"Sigfaibles_effectif_siret.csv\"", func(t *testing.T) {
-		got := GetFileType("Sigfaibles_effectif_siret.csv", DefaultMetadataReader)
-		assert.Equal(t, "effectif", got)
-	})
-
-	t.Run("should return \"debit\" for \"Sigfaibles_debits.csv\"", func(t *testing.T) {
-		got := GetFileType("Sigfaibles_debits.csv", DefaultMetadataReader)
-		assert.Equal(t, "debit", got)
-	})
-
-	t.Run("should return \"debit\" for \"Sigfaibles_debits2.csv\"", func(t *testing.T) {
-		got := GetFileType("Sigfaibles_debits2.csv", DefaultMetadataReader)
-		assert.Equal(t, "debit", got)
-	})
-
-	t.Run("should return \"cotisation\" for bin file which original name included \"cotisdues\"", func(t *testing.T) {
-		got := GetFileType("15b6ceeb928a3bc160b0e2dc2a794ad4.bin", MakeMetadataReader(map[string]string{
-			"filename":  "Sigfaible_cotisdues.csv",
-			"goup-path": "urssaf",
-		}))
-		assert.Equal(t, "cotisation", got)
-	})
 
 	t.Run("should return \"debit\" for bin file which original name included \"debits\"", func(t *testing.T) {
 		got := GetFileType("9a047825d8173684b69994428449302f.bin", MakeMetadataReader(map[string]string{
@@ -147,6 +125,10 @@ func TestGetFileType(t *testing.T) {
 		name     string
 		category string
 	}{
+		{"Sigfaibles_effectif_siret.csv", "effectif"},
+		{"Sigfaibles_debits.csv", "debit"},
+		{"Sigfaibles_debits2.csv", "debit"},
+		{"Sigfaible_cotisdues.csv", "cotisation"},
 		{"diane_req_2002.csv", "diane"},
 		{"diane_req_dom_2002.csv", "diane"},
 		{"effectif_dom.csv", "effectif"},

--- a/main_test.go
+++ b/main_test.go
@@ -120,7 +120,7 @@ func TestGetFileType(t *testing.T) {
 		assert.Equal(t, "debit", got)
 	})
 
-	t.Run("should return \"urssaf\" for bin file which come from urssaf", func(t *testing.T) {
+	t.Run("should return \"cotisation\" for bin file which come from urssaf", func(t *testing.T) {
 		got := GetFileType("15b6ceeb928a3bc160b0e2dc2a794ad4.bin", func(filename string) UploadedFileMeta {
 			return UploadedFileMeta{
 				"MetaData": map[string]string{
@@ -131,7 +131,7 @@ func TestGetFileType(t *testing.T) {
 				},
 			}
 		})
-		assert.Equal(t, "urssaf", got)
+		assert.Equal(t, "cotisation", got)
 	})
 
 	t.Run("should return \"debit\" for bin file which original name included \"debits\"", func(t *testing.T) {

--- a/main_test.go
+++ b/main_test.go
@@ -104,6 +104,12 @@ func TestPopulateFilesProperty(t *testing.T) {
 	})
 }
 
+func MakeMetadataReader(metadataFields map[string]string) func(string) UploadedFileMeta {
+	return func(filename string) UploadedFileMeta {
+		return UploadedFileMeta{"MetaData": metadataFields}
+	}
+}
+
 func TestGetFileType(t *testing.T) {
 	t.Run("should return \"effectif\" for \"Sigfaibles_effectif_siret.csv\"", func(t *testing.T) {
 		got := GetFileType("Sigfaibles_effectif_siret.csv", DefaultMetadataReader)
@@ -121,14 +127,10 @@ func TestGetFileType(t *testing.T) {
 	})
 
 	t.Run("should return \"cotisation\" for bin file which original name included \"cotisdues\"", func(t *testing.T) {
-		got := GetFileType("15b6ceeb928a3bc160b0e2dc2a794ad4.bin", func(filename string) UploadedFileMeta {
-			return UploadedFileMeta{
-				"MetaData": map[string]string{
-					"filename":  "Sigfaible_cotisdues.csv",
-					"goup-path": "urssaf",
-				},
-			}
-		})
+		got := GetFileType("15b6ceeb928a3bc160b0e2dc2a794ad4.bin", MakeMetadataReader(map[string]string{
+			"filename":  "Sigfaible_cotisdues.csv",
+			"goup-path": "urssaf",
+		}))
 		assert.Equal(t, "cotisation", got)
 	})
 

--- a/main_test.go
+++ b/main_test.go
@@ -128,6 +128,14 @@ func TestGetFileType(t *testing.T) {
 		assert.Equal(t, "bdf", got)
 	})
 
+	t.Run("should return \"interim\" for bin file which had a sas7dbat extension", func(t *testing.T) {
+		got := GetFileType("ab8613ab66ebddb2db21e36b92fc5b70.bin", MakeMetadataReader(map[string]string{
+			"filename":  "tab_19m10.sas7bdat",
+			"goup-path": "dgefp",
+		}))
+		assert.Equal(t, "interim", got)
+	})
+
 	// inspired by https://github.com/golang/go/wiki/TableDrivenTests
 	cases := []struct {
 		name     string

--- a/main_test.go
+++ b/main_test.go
@@ -110,6 +110,10 @@ func MakeMetadataReader(metadataFields map[string]string) func(string) UploadedF
 	}
 }
 
+func DummyMetadataReader(filename string) UploadedFileMeta {
+	return UploadedFileMeta{}
+}
+
 func TestGetFileType(t *testing.T) {
 
 	t.Run("should return \"debit\" for bin file which original name included \"debits\"", func(t *testing.T) {
@@ -169,7 +173,7 @@ func TestGetFileType(t *testing.T) {
 	}
 	for _, testCase := range cases {
 		t.Run("should return "+testCase.category+" for file "+testCase.name, func(t *testing.T) {
-			got := GetFileType(testCase.name, DefaultMetadataReader)
+			got := GetFileType(testCase.name, DummyMetadataReader)
 			assert.Equal(t, testCase.category, got)
 		})
 	}

--- a/main_test.go
+++ b/main_test.go
@@ -145,6 +145,10 @@ func TestGetFileType(t *testing.T) {
 		// {"xx.csv", "dpae"}, // Déclaration préalable à l'embauche => TODO: filename?
 		// {"xx.csv", "dmmo"}, // Déclaration annuelle des mouvements de main-d'œuvre => TODO: filename?
 
+		// guessed from dgefp files
+		{"act_partielle_conso_depuis2014_FRANCE.csv", "apconso"},
+		{"act_partielle_ddes_depuis2015_FRANCE.csv", "apdemande"},
+
 		// others
 		{"Sigfaibles_debits.csv", "debit"},
 		{"Sigfaibles_debits2.csv", "debit"},

--- a/main_test.go
+++ b/main_test.go
@@ -135,14 +135,10 @@ func TestGetFileType(t *testing.T) {
 	})
 
 	t.Run("should return \"debit\" for bin file which original name included \"debits\"", func(t *testing.T) {
-		got := GetFileType("9a047825d8173684b69994428449302f.bin", func(filename string) UploadedFileMeta {
-			return UploadedFileMeta{
-				"MetaData": map[string]string{
-					"filename":  "Sigfaible_debits.csv",
-					"goup-path": "urssaf",
-				},
-			}
-		})
+		got := GetFileType("9a047825d8173684b69994428449302f.bin", MakeMetadataReader(map[string]string{
+			"filename":  "Sigfaible_debits.csv",
+			"goup-path": "urssaf",
+		}))
 		assert.Equal(t, "debit", got)
 	})
 

--- a/main_test.go
+++ b/main_test.go
@@ -134,6 +134,20 @@ func TestGetFileType(t *testing.T) {
 		assert.Equal(t, "urssaf", got)
 	})
 
+	t.Run("should return \"debit\" for bin file which original name included \"debits\"", func(t *testing.T) {
+		got := GetFileType("15b6ceeb928a3bc160b0e2dc2a794ad4.bin", func(filename string) UploadedFileMeta {
+			return UploadedFileMeta{
+				"MetaData": map[string]string{
+					"filename":  "Sigfaible_debits.csv",
+					"filetype":  "application/vnd.ms-excel",
+					"goup-path": "urssaf",
+					"private":   "false",
+				},
+			}
+		})
+		assert.Equal(t, "debit", got)
+	})
+
 	// inspired by https://github.com/golang/go/wiki/TableDrivenTests
 	cases := []struct {
 		name     string


### PR DESCRIPTION
J'ai deviné le types de la plupart des fichiers `bin` présents dans le dossier `/var/lib/goup_base/public/2002` du serveur `stockage`, à partir des métadonnées fournies dans les fichiers `info` correspondants, et la table fournie dans la section suivante de la documentation: https://github.com/signaux-faibles/documentation/blob/master/processus-traitement-donnees.md#sp%C3%A9cificit%C3%A9s-de-limport.

## Revue

Avant de fusionner cette PR:
- vérifier que les mappings devinés sont corrects
- quel est le type du fichier `Sigfaible_etablissement_utf8.csv` ?
- comment reconnaitre les fichiers de type `dpae` et `dmmo` ?