### PR TITLE
fix: Correction des types incorrects + Retrait de récursion

### DIFF
--- a/main.go
+++ b/main.go
@@ -93,6 +93,10 @@ func GetFileType(filename string, getFileMeta func(string) UploadedFileMeta) str
 		return "apconso"
 	case filename == "act_partielle_ddes_depuis2015_FRANCE.csv":
 		return "apdemande"
+	case filename == "Sigfaible_etablissement_utf8.csv":
+		return "admin_urssaf"
+	case filename == "Sigfaible_effectif_siren.csv":
+		return "effectif_ent"
 	case filename == "Sigfaible_pcoll.csv":
 		return "procol"
 	case filename == "Sigfaible_cotisdues.csv":

--- a/main_test.go
+++ b/main_test.go
@@ -68,7 +68,7 @@ func TestPrepareImport(t *testing.T) {
 // Prepare import should return json object.
 func TestPurePrepareImport(t *testing.T) {
 	t.Run("Should return a json with one file", func(t *testing.T) {
-		res := PurePrepareImport([]string{"Sigfaibles_debits.csv"})
+		res := PurePrepareImport([]string{"Sigfaibles_debits.csv"}, "")
 		expected := AdminObject{
 			"files": FilesProperty{"debit": []string{"Sigfaibles_debits.csv"}},
 		}
@@ -76,7 +76,7 @@ func TestPurePrepareImport(t *testing.T) {
 	})
 
 	t.Run("Should return an empty json when there is no file", func(t *testing.T) {
-		res := PurePrepareImport([]string{})
+		res := PurePrepareImport([]string{}, "")
 		assert.Equal(t, AdminObject{"files": FilesProperty{}}, res)
 	})
 
@@ -89,7 +89,7 @@ func TestPurePrepareImport(t *testing.T) {
 			"sireneUL.csv",                    // --> "sirene_ul"
 			"StockEtablissement_utf8_geo.csv", // --> "comptes"
 		}
-		res := PurePrepareImport(files)
+		res := PurePrepareImport(files, "")
 		resFilesProperty := res["files"].(FilesProperty)
 		resultingFiles := []string{}
 		for _, filenames := range resFilesProperty {
@@ -101,34 +101,34 @@ func TestPurePrepareImport(t *testing.T) {
 
 func TestPopulateFilesProperty(t *testing.T) {
 	t.Run("PopulateFilesProperty should contain effectif file in \"effectif\" property", func(t *testing.T) {
-		filesProperty := PopulateFilesProperty([]string{"Sigfaibles_effectif_siret.csv"})
+		filesProperty := PopulateFilesProperty([]string{"Sigfaibles_effectif_siret.csv"}, "")
 		assert.Equal(t, []string{"Sigfaibles_effectif_siret.csv"}, filesProperty["effectif"])
 	})
 
 	t.Run("PopulateFilesProperty should contain one debit file in \"debit\" property", func(t *testing.T) {
-		filesProperty := PopulateFilesProperty([]string{"Sigfaibles_debits.csv"})
+		filesProperty := PopulateFilesProperty([]string{"Sigfaibles_debits.csv"}, "")
 		assert.Equal(t, []string{"Sigfaibles_debits.csv"}, filesProperty["debit"])
 	})
 
 	t.Run("PopulateFilesProperty should contain both debits files in \"debit\" property", func(t *testing.T) {
-		filesProperty := PopulateFilesProperty([]string{"Sigfaibles_debits.csv", "Sigfaibles_debits2.csv"})
+		filesProperty := PopulateFilesProperty([]string{"Sigfaibles_debits.csv", "Sigfaibles_debits2.csv"}, "")
 		assert.Equal(t, []string{"Sigfaibles_debits.csv", "Sigfaibles_debits2.csv"}, filesProperty["debit"])
 	})
 
 	t.Run("Should not include unsupported files", func(t *testing.T) {
-		filesProperty := PopulateFilesProperty([]string{"coco.csv"})
+		filesProperty := PopulateFilesProperty([]string{"coco.csv"}, "")
 		assert.Equal(t, FilesProperty{}, filesProperty)
 	})
 }
 
-func MakeMetadata(metadataFields map[string]string) UploadedFileMeta {
-	return UploadedFileMeta{"MetaData": metadataFields}
+func MakeMetadata(metadataFields MetadataProperty) UploadedFileMeta {
+	return UploadedFileMeta{MetaData: metadataFields}
 }
 
 func TestGetFileType(t *testing.T) {
 
 	t.Run("should return \"debit\" for bin file which original name included \"debits\"", func(t *testing.T) {
-		got := GetFileTypeFromMetadata("9a047825d8173684b69994428449302f.bin", MakeMetadata(map[string]string{
+		got := GetFileTypeFromMetadata("9a047825d8173684b69994428449302f.bin", MakeMetadata(MetadataProperty{
 			"filename":  "Sigfaible_debits.csv",
 			"goup-path": "urssaf",
 		}))
@@ -136,7 +136,7 @@ func TestGetFileType(t *testing.T) {
 	})
 
 	t.Run("should return \"bdf\" for bin file which came from bdf", func(t *testing.T) {
-		got := GetFileTypeFromMetadata("60d1bd320523904d8b8b427efbbd3928.bin", MakeMetadata(map[string]string{
+		got := GetFileTypeFromMetadata("60d1bd320523904d8b8b427efbbd3928.bin", MakeMetadata(MetadataProperty{
 			"filename":  "FICHIER_SF_2020_02.csv",
 			"goup-path": "bdf",
 		}))
@@ -144,7 +144,7 @@ func TestGetFileType(t *testing.T) {
 	})
 
 	t.Run("should return \"interim\" for bin file which had a sas7dbat extension", func(t *testing.T) {
-		got := GetFileTypeFromMetadata("ab8613ab66ebddb2db21e36b92fc5b70.bin", MakeMetadata(map[string]string{
+		got := GetFileTypeFromMetadata("ab8613ab66ebddb2db21e36b92fc5b70.bin", MakeMetadata(MetadataProperty{
 			"filename":  "tab_19m10.sas7bdat",
 			"goup-path": "dgefp",
 		}))

--- a/main_test.go
+++ b/main_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+// Helper to create temporary files, and clean up after the execution of tests
 func createTempFiles(t *testing.T, filename string) string {
 	t.Helper()
 	dir, err := ioutil.TempDir(os.TempDir(), "example")
@@ -43,6 +44,22 @@ func TestPrepareImport(t *testing.T) {
 		res, _ := PrepareImport(dir)
 		expected := AdminObject{
 			"files": FilesProperty{"debit": []string{"Sigfaibles_debits.csv"}},
+		}
+		assert.Equal(t, expected, res)
+	})
+
+	t.Run("Should support uploaded files (bin+info)", func(t *testing.T) {
+		dir := createTempFiles(t, "9a047825d8173684b69994428449302f.bin")
+
+		tmpFilename := filepath.Join(dir, "9a047825d8173684b69994428449302f.info")
+		content := []byte("{\"MetaData\":{\"filename\":\"Sigfaible_debits.csv\",\"goup-path\":\"urssaf\"}}")
+		if err := ioutil.WriteFile(tmpFilename, content, 0666); err != nil {
+			t.Fatal(err.Error())
+		}
+
+		res, _ := PrepareImport(dir)
+		expected := AdminObject{
+			"files": FilesProperty{"debit": []string{"9a047825d8173684b69994428449302f.bin"}},
 		}
 		assert.Equal(t, expected, res)
 	})

--- a/main_test.go
+++ b/main_test.go
@@ -149,13 +149,11 @@ func TestGetFileType(t *testing.T) {
 		{"Sigfaible_debits.csv", "debit"},
 		{"Sigfaible_cotisdues.csv", "cotisation"},
 		{"Sigfaible_pcoll.csv", "procol"},
-		// {"Sigfaible_etablissement_utf8.csv", "admin_urssaf"}, // to be confirmed
-		{"Sigfaible_effectif_siret.csv.csv", "effectif"}, // to be confirmed
-		{"Sigfaible_effectif_siren.csv.csv", "effectif"}, // to be confirmed
+		{"Sigfaible_etablissement_utf8.csv", "admin_urssaf"},
+		{"Sigfaible_effectif_siret.csv", "effectif"},
+		{"Sigfaible_effectif_siren.csv", "effectif_ent"},
 		{"Sigfaible_delais.csv", "delai"},
 		{"Sigfaible_ccsf.csv", "ccsf"},
-		// {"xx.csv", "dpae"}, // Déclaration préalable à l'embauche => TODO: filename?
-		// {"xx.csv", "dmmo"}, // Déclaration annuelle des mouvements de main-d'œuvre => TODO: filename?
 
 		// guessed from dgefp files
 		{"act_partielle_conso_depuis2014_FRANCE.csv", "apconso"},

--- a/main_test.go
+++ b/main_test.go
@@ -104,20 +104,14 @@ func TestPopulateFilesProperty(t *testing.T) {
 	})
 }
 
-func MakeMetadataReader(metadataFields map[string]string) func(string) UploadedFileMeta {
-	return func(filename string) UploadedFileMeta {
-		return UploadedFileMeta{"MetaData": metadataFields}
-	}
-}
-
-func DummyMetadataReader(filename string) UploadedFileMeta {
-	return UploadedFileMeta{}
+func MakeMetadata(metadataFields map[string]string) UploadedFileMeta {
+	return UploadedFileMeta{"MetaData": metadataFields}
 }
 
 func TestGetFileType(t *testing.T) {
 
 	t.Run("should return \"debit\" for bin file which original name included \"debits\"", func(t *testing.T) {
-		got := GetFileType("9a047825d8173684b69994428449302f.bin", MakeMetadataReader(map[string]string{
+		got := GetFileTypeFromMetadata("9a047825d8173684b69994428449302f.bin", MakeMetadata(map[string]string{
 			"filename":  "Sigfaible_debits.csv",
 			"goup-path": "urssaf",
 		}))
@@ -125,7 +119,7 @@ func TestGetFileType(t *testing.T) {
 	})
 
 	t.Run("should return \"bdf\" for bin file which came from bdf", func(t *testing.T) {
-		got := GetFileType("60d1bd320523904d8b8b427efbbd3928.bin", MakeMetadataReader(map[string]string{
+		got := GetFileTypeFromMetadata("60d1bd320523904d8b8b427efbbd3928.bin", MakeMetadata(map[string]string{
 			"filename":  "FICHIER_SF_2020_02.csv",
 			"goup-path": "bdf",
 		}))
@@ -133,7 +127,7 @@ func TestGetFileType(t *testing.T) {
 	})
 
 	t.Run("should return \"interim\" for bin file which had a sas7dbat extension", func(t *testing.T) {
-		got := GetFileType("ab8613ab66ebddb2db21e36b92fc5b70.bin", MakeMetadataReader(map[string]string{
+		got := GetFileTypeFromMetadata("ab8613ab66ebddb2db21e36b92fc5b70.bin", MakeMetadata(map[string]string{
 			"filename":  "tab_19m10.sas7bdat",
 			"goup-path": "dgefp",
 		}))
@@ -171,7 +165,7 @@ func TestGetFileType(t *testing.T) {
 	}
 	for _, testCase := range cases {
 		t.Run("should return "+testCase.category+" for file "+testCase.name, func(t *testing.T) {
-			got := GetFileType(testCase.name, DummyMetadataReader)
+			got := GetFileType(testCase.name)
 			assert.Equal(t, testCase.category, got)
 		})
 	}


### PR DESCRIPTION
Changements basés sur revue de https://github.com/signaux-faibles/prepare-import/pull/10:

- correction des types pour `Sigfaible_etablissement_utf8.csv`, `Sigfaible_effectif_siret.csv` et `Sigfaible_effectif_siren.csv`
- Retrait de récursion => `GetFileType()` ne prend plus de `Reader()` en paramètre => la responsabilité de lire les métadonnées revient à `PopulateFilesProperty()`

## Suites prévues

- Vu que `PurePrepareImport()` appelle `PopulateFilesProperty()`, qui repose sur le système de fichiers pour lire les métadonnées, `PurePrepareImport()` n'est au final plus une fonction pure. => voir si on peut extraire les appels au système de fichiers afin de rendre cette fonction à nouveau pure.
- sérialiser le résultat de `./prepare-import` au format JSON.