### PR TITLE
refactor: Rerendre pures les fonctions pures + nommage + séparation fichier

### DIFF
--- a/main.go
+++ b/main.go
@@ -19,8 +19,11 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	fmt.Println(adminObject)
-	// TODO: serialize to JSON string
+  json, err := json.MarshalIndent(adminObject, "", "  ")
+  if (err != nil) {
+    log.Fatal(err)
+  }
+	fmt.Println(string(json))
 }
 
 type AdminObject map[string]interface{}

--- a/main.go
+++ b/main.go
@@ -38,6 +38,21 @@ func (ffn SimpleFilename) GetOriginalFilename() string {
 	return ffn.filename
 }
 
+type UploadedFilename struct {
+  filename string
+  path string
+}
+
+func (ffn UploadedFilename) GetOriginalFilename() string {
+  //TODO read from metadata
+  // return ffn.filename
+  return ffn.filename
+}
+
+func (ffn UploadedFilename) GetFilenameToImport() string {
+  return ffn.filename
+}
+
 func PrepareImport(pathname string) (AdminObject, error) {
 	filenames, err := ReadFilenames(pathname)
 	if err != nil {
@@ -45,7 +60,13 @@ func PrepareImport(pathname string) (AdminObject, error) {
 	}
 	augmentedFiles := []Filename{}
 	for _, file := range filenames {
-		augmentedFiles = append(augmentedFiles, SimpleFilename{file})
+    var filename Filename
+    if strings.HasSuffix(file, ".bin") {
+      filename = UploadedFilename{file, pathname}
+    } else {
+      filename = SimpleFilename{file}
+    }
+		augmentedFiles = append(augmentedFiles, filename)
 	}
 	return PurePrepareImport(augmentedFiles), nil
 }

--- a/main.go
+++ b/main.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"encoding/json"
+	"flag"
+	"fmt"
 	"log"
 	"path/filepath"
 
@@ -13,17 +15,17 @@ import (
 )
 
 func main() {
-	// var path = flag.String("path", ".", "Chemin d'accès aux fichiers données")
-	// flag.Parse()
-	// adminObject, err := PrepareImport(*path)
-	// if err != nil {
-	// 	log.Fatal(err)
-	// }
-	// json, err := json.MarshalIndent(adminObject, "", "  ")
-	// if err != nil {
-	// 	log.Fatal(err)
-	// }
-	// fmt.Println(string(json))
+	var path = flag.String("path", ".", "Chemin d'accès aux fichiers données")
+	flag.Parse()
+	adminObject, err := PrepareImport(*path)
+	if err != nil {
+		log.Fatal(err)
+	}
+	json, err := json.MarshalIndent(adminObject, "", "  ")
+	if err != nil {
+		log.Fatal(err)
+	}
+	fmt.Println(string(json))
 }
 
 type AdminObject map[string]interface{}

--- a/main.go
+++ b/main.go
@@ -8,7 +8,6 @@ import (
 	// "flag"
 	// "fmt"
 	"io/ioutil"
-	// "log"
 	"regexp"
 	"strings"
 )
@@ -29,11 +28,9 @@ func main() {
 
 type AdminObject map[string]interface{}
 
-
 type Filename interface {
 	GetFilenameToImport() string // the name as it will be stored in Admin
-	GetOriginalFilename() string // the name as it may be defined in the metadata file
-  GetFiletype() string
+	GetFiletype() string
 }
 
 type SimpleFilename struct {
@@ -41,14 +38,10 @@ type SimpleFilename struct {
 }
 
 func (ffn SimpleFilename) GetFiletype() string {
-  return GetFileType(ffn.filename)
+	return GetFileType(ffn.filename)
 }
 
 func (ffn SimpleFilename) GetFilenameToImport() string {
-	return ffn.filename
-}
-
-func (ffn SimpleFilename) GetOriginalFilename() string {
 	return ffn.filename
 }
 
@@ -57,25 +50,14 @@ type UploadedFilename struct {
 	path     string
 }
 
-
 func (ffn UploadedFilename) GetFiletype() string {
 	metaFilepath := filepath.Join(ffn.path, strings.Replace(ffn.filename, ".bin", ".info", 1))
 	fileinfo, err := LoadMetadata(metaFilepath)
 	if err != nil {
 		log.Fatal(err)
 	}
-  filetype := GetFileTypeFromMetadata(metaFilepath, fileinfo)
+	filetype := GetFileTypeFromMetadata(metaFilepath, fileinfo)
 	return filetype // e.g. "Sigfaible_debits.csv"
-}
-
-func (ffn UploadedFilename) GetOriginalFilename() string {
-	metaFilepath := filepath.Join(ffn.path, strings.Replace(ffn.filename, ".bin", ".info", 1))
-	fileinfo, err := LoadMetadata(metaFilepath)
-	if err != nil {
-		log.Fatal(err)
-	}
-	// filetype = GetFileTypeFromMetadata(filename, fileinfo)
-	return fileinfo.MetaData["filename"] // e.g. "Sigfaible_debits.csv"
 }
 
 func (ffn UploadedFilename) GetFilenameToImport() string {
@@ -99,13 +81,6 @@ func PrepareImport(pathname string) (AdminObject, error) {
 	}
 	return PurePrepareImport(augmentedFiles), nil
 }
-
-// TODO: OldPurePrepareImport is not pure anymore, because it takes a path, and can indirectly read files
-// func OldPurePrepareImport(filenames []string, path string) AdminObject {
-// 	filesProperty := PopulateFilesProperty(filenames, path)
-// 	return AdminObject{"files": filesProperty}
-// }
-
 
 func PurePrepareImport(augmentedFilenames []Filename) AdminObject {
 	filesProperty := PopulateFilesProperty(augmentedFilenames)
@@ -144,44 +119,10 @@ func LoadMetadata(filepath string) (UploadedFileMeta, error) {
 	return uploadedFileMeta, nil
 }
 
-// func PopulateFilesProperty(filenames []string, path string) FilesProperty {
-// 	filesProperty := FilesProperty{
-// 		// "effectif": []string{"coucou"},
-// 		// "debit":    []string{},
-// 	}
-// 	for _, filename := range filenames {
-// 		var filetype string
-// 		if strings.HasSuffix(filename, ".bin") {
-// 			metaFilepath := filepath.Join(path, strings.Replace(filename, ".bin", ".info", 1))
-// 			fileinfo, err := LoadMetadata(metaFilepath)
-// 			if err != nil {
-// 				log.Fatal(err)
-// 			}
-// 			filetype = GetFileTypeFromMetadata(filename, fileinfo)
-// 		} else {
-// 			filetype = GetFileType(filename)
-// 		}
-// 		if filetype == "" {
-// 			// Unsupported file
-// 			continue
-// 		}
-// 		if _, exists := filesProperty[filetype]; !exists {
-// 			filesProperty[filetype] = []string{}
-// 		}
-// 		filesProperty[filetype] = append(filesProperty[filetype], filename)
-// 	}
-// 	return filesProperty
-// }
-
 func PopulateFilesProperty(filenames []Filename) FilesProperty {
-	filesProperty := FilesProperty{
-		// "effectif": []string{"coucou"},
-		// "debit":    []string{},
-	}
+	filesProperty := FilesProperty{}
 	for _, filename := range filenames {
-		var filetype string
-
-		filetype = GetFileType(filename.GetOriginalFilename())
+		filetype := filename.GetFiletype()
 
 		if filetype == "" {
 			// Unsupported file

--- a/main.go
+++ b/main.go
@@ -2,6 +2,9 @@ package main
 
 import (
 	"encoding/json"
+	"log"
+	"path/filepath"
+
 	// "flag"
 	// "fmt"
 	"io/ioutil"
@@ -39,18 +42,22 @@ func (ffn SimpleFilename) GetOriginalFilename() string {
 }
 
 type UploadedFilename struct {
-  filename string
-  path string
+	filename string
+	path     string
 }
 
 func (ffn UploadedFilename) GetOriginalFilename() string {
-  //TODO read from metadata
-  // return ffn.filename
-  return ffn.filename
+	metaFilepath := filepath.Join(ffn.path, strings.Replace(ffn.filename, ".bin", ".info", 1))
+	fileinfo, err := LoadMetadata(metaFilepath)
+	if err != nil {
+		log.Fatal(err)
+	}
+	// filetype = GetFileTypeFromMetadata(filename, fileinfo)
+	return fileinfo.MetaData["filename"] // e.g. "Sigfaible_debits.csv"
 }
 
 func (ffn UploadedFilename) GetFilenameToImport() string {
-  return ffn.filename
+	return ffn.filename
 }
 
 func PrepareImport(pathname string) (AdminObject, error) {
@@ -60,12 +67,12 @@ func PrepareImport(pathname string) (AdminObject, error) {
 	}
 	augmentedFiles := []Filename{}
 	for _, file := range filenames {
-    var filename Filename
-    if strings.HasSuffix(file, ".bin") {
-      filename = UploadedFilename{file, pathname}
-    } else {
-      filename = SimpleFilename{file}
-    }
+		var filename Filename
+		if strings.HasSuffix(file, ".bin") {
+			filename = UploadedFilename{file, pathname}
+		} else {
+			filename = SimpleFilename{file}
+		}
 		augmentedFiles = append(augmentedFiles, filename)
 	}
 	return PurePrepareImport(augmentedFiles), nil

--- a/main.go
+++ b/main.go
@@ -12,17 +12,16 @@ import (
 )
 
 func main() {
-	// flags
 	var path = flag.String("path", ".", "Chemin d'accès aux fichiers données")
 	flag.Parse()
 	adminObject, err := PrepareImport(*path)
 	if err != nil {
 		log.Fatal(err)
 	}
-  json, err := json.MarshalIndent(adminObject, "", "  ")
-  if (err != nil) {
-    log.Fatal(err)
-  }
+	json, err := json.MarshalIndent(adminObject, "", "  ")
+	if err != nil {
+		log.Fatal(err)
+	}
 	fmt.Println(string(json))
 }
 
@@ -33,11 +32,20 @@ func PrepareImport(pathname string) (AdminObject, error) {
 	if err != nil {
 		return nil, err
 	}
-	return PurePrepareImport(filenames, pathname), nil
+	return OldPurePrepareImport(filenames, pathname), nil
 }
 
-// TODO: PurePrepareImport is not pure anymore, because it takes a path, and can indirectly read files
-func PurePrepareImport(filenames []string, path string) AdminObject {
+// TODO: OldPurePrepareImport is not pure anymore, because it takes a path, and can indirectly read files
+func OldPurePrepareImport(filenames []string, path string) AdminObject {
+	filesProperty := PopulateFilesProperty(filenames, path)
+	return AdminObject{"files": filesProperty}
+}
+
+type Filename interface{
+	func GetFilenameToImport() string
+}
+
+func PurePrepareImport(augmentedFilenames []Filename) AdminObject {
 	filesProperty := PopulateFilesProperty(filenames, path)
 	return AdminObject{"files": filesProperty}
 }

--- a/main.go
+++ b/main.go
@@ -7,8 +7,6 @@ import (
 	"log"
 	"path/filepath"
 
-	// "flag"
-	// "fmt"
 	"io/ioutil"
 	"regexp"
 	"strings"
@@ -32,14 +30,14 @@ type AdminObject map[string]interface{}
 
 type Filename interface {
 	GetFilenameToImport() string // the name as it will be stored in Admin
-	GetFiletype() string
+	DetectFileType() string
 }
 
 type SimpleFilename struct {
 	filename string
 }
 
-func (ffn SimpleFilename) GetFiletype() string {
+func (ffn SimpleFilename) DetectFileType() string {
 	return GetFileType(ffn.filename)
 }
 
@@ -52,7 +50,7 @@ type UploadedFilename struct {
 	path     string
 }
 
-func (ffn UploadedFilename) GetFiletype() string {
+func (ffn UploadedFilename) DetectFileType() string {
 	metaFilepath := filepath.Join(ffn.path, strings.Replace(ffn.filename, ".bin", ".info", 1))
 	fileinfo, err := LoadMetadata(metaFilepath)
 	if err != nil {
@@ -124,7 +122,7 @@ func LoadMetadata(filepath string) (UploadedFileMeta, error) {
 func PopulateFilesProperty(filenames []Filename) FilesProperty {
 	filesProperty := FilesProperty{}
 	for _, filename := range filenames {
-		filetype := filename.GetFiletype()
+		filetype := filename.DetectFileType()
 
 		if filetype == "" {
 			// Unsupported file

--- a/main.go
+++ b/main.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"log"
-	"path/filepath"
 	"regexp"
 	"strings"
 )
@@ -41,13 +40,13 @@ func OldPurePrepareImport(filenames []string, path string) AdminObject {
 	return AdminObject{"files": filesProperty}
 }
 
-type Filename interface{
+type Filename interface {
 	GetFilenameToImport() string // the name as it will be stored in Admin
-  GetOriginalFilename() string // the name as it may be defined in the metadata file
+	GetOriginalFilename() string // the name as it may be defined in the metadata file
 }
 
 func PurePrepareImport(augmentedFilenames []Filename) AdminObject {
-	filesProperty := PopulateFilesProperty(filenames, path)
+	filesProperty := PopulateFilesProperty(augmentedFilenames)
 	return AdminObject{"files": filesProperty}
 }
 
@@ -83,19 +82,45 @@ func LoadMetadata(filepath string) (UploadedFileMeta, error) {
 	return uploadedFileMeta, nil
 }
 
-func PopulateFilesProperty(filenames []string, path string) FilesProperty {
+// func PopulateFilesProperty(filenames []string, path string) FilesProperty {
+// 	filesProperty := FilesProperty{
+// 		// "effectif": []string{"coucou"},
+// 		// "debit":    []string{},
+// 	}
+// 	for _, filename := range filenames {
+// 		var filetype string
+// 		if strings.HasSuffix(filename, ".bin") {
+// 			metaFilepath := filepath.Join(path, strings.Replace(filename, ".bin", ".info", 1))
+// 			fileinfo, err := LoadMetadata(metaFilepath)
+// 			if err != nil {
+// 				log.Fatal(err)
+// 			}
+// 			filetype = GetFileTypeFromMetadata(filename, fileinfo)
+// 		} else {
+// 			filetype = GetFileType(filename)
+// 		}
+// 		if filetype == "" {
+// 			// Unsupported file
+// 			continue
+// 		}
+// 		if _, exists := filesProperty[filetype]; !exists {
+// 			filesProperty[filetype] = []string{}
+// 		}
+// 		filesProperty[filetype] = append(filesProperty[filetype], filename)
+// 	}
+// 	return filesProperty
+// }
+
+func PopulateFilesProperty(filenames []Filename) FilesProperty {
 	filesProperty := FilesProperty{
 		// "effectif": []string{"coucou"},
 		// "debit":    []string{},
 	}
 	for _, filename := range filenames {
 		var filetype string
-		if strings.HasSuffix(filename, ".bin") {
-			metaFilepath := filepath.Join(path, strings.Replace(filename, ".bin", ".info", 1))
-			fileinfo, err := LoadMetadata(metaFilepath)
-			if err != nil {
-				log.Fatal(err)
-			}
+		if strings.HasSuffix(filename.GetFilenameToImport(), ".bin") {
+			filename.GetOriginalFilename()
+
 			filetype = GetFileTypeFromMetadata(filename, fileinfo)
 		} else {
 			filetype = GetFileType(filename)

--- a/main.go
+++ b/main.go
@@ -188,14 +188,14 @@ type UploadedFileMeta struct {
 	MetaData MetadataProperty
 }
 
-func GetFileTypeFromMetadata(filename string, fileinfo UploadedFileMeta) string {
-	metadata := fileinfo.MetaData
-	if metadata["goup-path"] == "bdf" {
-		return "bdf"
-	} else {
-		return GetFileType(metadata["filename"])
-	}
-}
+// func GetFileTypeFromMetadata(filename string, fileinfo UploadedFileMeta) string {
+// 	metadata := fileinfo.MetaData
+// 	if metadata["goup-path"] == "bdf" {
+// 		return "bdf"
+// 	} else {
+// 		return GetFileType(metadata["filename"])
+// 	}
+// }
 
 // GetFileType returns a file type from filename, or empty string for unsupported file names
 func GetFileType(filename string) string {

--- a/main.go
+++ b/main.go
@@ -26,13 +26,29 @@ func main() {
 
 type AdminObject map[string]interface{}
 
-// func PrepareImport(pathname string) (AdminObject, error) {
-// 	filenames, err := ReadFilenames(pathname)
-// 	if err != nil {
-// 		return nil, err
-// 	}
-// 	return PurePrepareImport(filenames, pathname), nil
-// }
+type SimpleFilename struct {
+	filename string
+}
+
+func (ffn SimpleFilename) GetFilenameToImport() string {
+	return ffn.filename
+}
+
+func (ffn SimpleFilename) GetOriginalFilename() string {
+	return ffn.filename
+}
+
+func PrepareImport(pathname string) (AdminObject, error) {
+	filenames, err := ReadFilenames(pathname)
+	if err != nil {
+		return nil, err
+	}
+	augmentedFiles := []Filename{}
+	for _, file := range filenames {
+		augmentedFiles = append(augmentedFiles, SimpleFilename{file})
+	}
+	return PurePrepareImport(augmentedFiles), nil
+}
 
 // TODO: OldPurePrepareImport is not pure anymore, because it takes a path, and can indirectly read files
 // func OldPurePrepareImport(filenames []string, path string) AdminObject {

--- a/main.go
+++ b/main.go
@@ -42,7 +42,8 @@ func OldPurePrepareImport(filenames []string, path string) AdminObject {
 }
 
 type Filename interface{
-	func GetFilenameToImport() string
+	GetFilenameToImport() string // the name as it will be stored in Admin
+  GetOriginalFilename() string // the name as it may be defined in the metadata file
 }
 
 func PurePrepareImport(augmentedFilenames []Filename) AdminObject {

--- a/main.go
+++ b/main.go
@@ -2,43 +2,43 @@ package main
 
 import (
 	"encoding/json"
-	"flag"
-	"fmt"
+	// "flag"
+	// "fmt"
 	"io/ioutil"
-	"log"
+	// "log"
 	"regexp"
 	"strings"
 )
 
 func main() {
-	var path = flag.String("path", ".", "Chemin d'accès aux fichiers données")
-	flag.Parse()
-	adminObject, err := PrepareImport(*path)
-	if err != nil {
-		log.Fatal(err)
-	}
-	json, err := json.MarshalIndent(adminObject, "", "  ")
-	if err != nil {
-		log.Fatal(err)
-	}
-	fmt.Println(string(json))
+	// var path = flag.String("path", ".", "Chemin d'accès aux fichiers données")
+	// flag.Parse()
+	// adminObject, err := PrepareImport(*path)
+	// if err != nil {
+	// 	log.Fatal(err)
+	// }
+	// json, err := json.MarshalIndent(adminObject, "", "  ")
+	// if err != nil {
+	// 	log.Fatal(err)
+	// }
+	// fmt.Println(string(json))
 }
 
 type AdminObject map[string]interface{}
 
-func PrepareImport(pathname string) (AdminObject, error) {
-	filenames, err := ReadFilenames(pathname)
-	if err != nil {
-		return nil, err
-	}
-	return OldPurePrepareImport(filenames, pathname), nil
-}
+// func PrepareImport(pathname string) (AdminObject, error) {
+// 	filenames, err := ReadFilenames(pathname)
+// 	if err != nil {
+// 		return nil, err
+// 	}
+// 	return PurePrepareImport(filenames, pathname), nil
+// }
 
 // TODO: OldPurePrepareImport is not pure anymore, because it takes a path, and can indirectly read files
-func OldPurePrepareImport(filenames []string, path string) AdminObject {
-	filesProperty := PopulateFilesProperty(filenames, path)
-	return AdminObject{"files": filesProperty}
-}
+// func OldPurePrepareImport(filenames []string, path string) AdminObject {
+// 	filesProperty := PopulateFilesProperty(filenames, path)
+// 	return AdminObject{"files": filesProperty}
+// }
 
 type Filename interface {
 	GetFilenameToImport() string // the name as it will be stored in Admin
@@ -118,13 +118,9 @@ func PopulateFilesProperty(filenames []Filename) FilesProperty {
 	}
 	for _, filename := range filenames {
 		var filetype string
-		if strings.HasSuffix(filename.GetFilenameToImport(), ".bin") {
-			filename.GetOriginalFilename()
 
-			filetype = GetFileTypeFromMetadata(filename, fileinfo)
-		} else {
-			filetype = GetFileType(filename)
-		}
+    filetype = GetFileType(filename.GetOriginalFilename())
+
 		if filetype == "" {
 			// Unsupported file
 			continue
@@ -132,7 +128,7 @@ func PopulateFilesProperty(filenames []Filename) FilesProperty {
 		if _, exists := filesProperty[filetype]; !exists {
 			filesProperty[filetype] = []string{}
 		}
-		filesProperty[filetype] = append(filesProperty[filetype], filename)
+		filesProperty[filetype] = append(filesProperty[filetype], filename.GetFilenameToImport())
 	}
 	return filesProperty
 }

--- a/main.go
+++ b/main.go
@@ -119,7 +119,7 @@ func PopulateFilesProperty(filenames []Filename) FilesProperty {
 	for _, filename := range filenames {
 		var filetype string
 
-    filetype = GetFileType(filename.GetOriginalFilename())
+		filetype = GetFileType(filename.GetOriginalFilename())
 
 		if filetype == "" {
 			// Unsupported file

--- a/main_test.go
+++ b/main_test.go
@@ -83,9 +83,9 @@ func TestPrepareImport(t *testing.T) {
 
 func TestPurePrepareImport(t *testing.T) {
 	t.Run("Should return the filename in the debit property", func(t *testing.T) {
-		filename := SimpleFilename{"Sigfaibles_debits.csv"}
+		filename := SimpleDataFile{"Sigfaibles_debits.csv"}
 
-		res := PurePrepareImport([]Filename{filename})
+		res := PurePrepareImport([]DataFile{filename})
 		expected := AdminObject{
 			"files": FilesProperty{"debit": []string{"Sigfaibles_debits.csv"}},
 		}
@@ -93,7 +93,7 @@ func TestPurePrepareImport(t *testing.T) {
 	})
 
 	t.Run("Should return an empty json when there is no file", func(t *testing.T) {
-		res := PurePrepareImport([]Filename{})
+		res := PurePrepareImport([]DataFile{})
 		assert.Equal(t, AdminObject{"files": FilesProperty{}}, res)
 	})
 
@@ -106,9 +106,9 @@ func TestPurePrepareImport(t *testing.T) {
 			"sireneUL.csv",                    // --> "sirene_ul"
 			"StockEtablissement_utf8_geo.csv", // --> "comptes"
 		}
-		augmentedFiles := []Filename{}
+		augmentedFiles := []DataFile{}
 		for _, file := range files {
-			augmentedFiles = append(augmentedFiles, SimpleFilename{file})
+			augmentedFiles = append(augmentedFiles, SimpleDataFile{file})
 		}
 		res := PurePrepareImport(augmentedFiles)
 		resFilesProperty := res["files"].(FilesProperty)
@@ -122,22 +122,22 @@ func TestPurePrepareImport(t *testing.T) {
 
 func TestPopulateFilesProperty(t *testing.T) {
 	t.Run("PopulateFilesProperty should contain effectif file in \"effectif\" property", func(t *testing.T) {
-		filesProperty := PopulateFilesProperty([]Filename{SimpleFilename{"Sigfaibles_effectif_siret.csv"}})
+		filesProperty := PopulateFilesProperty([]DataFile{SimpleDataFile{"Sigfaibles_effectif_siret.csv"}})
 		assert.Equal(t, []string{"Sigfaibles_effectif_siret.csv"}, filesProperty["effectif"])
 	})
 
 	t.Run("PopulateFilesProperty should contain one debit file in \"debit\" property", func(t *testing.T) {
-		filesProperty := PopulateFilesProperty([]Filename{SimpleFilename{"Sigfaibles_debits.csv"}})
+		filesProperty := PopulateFilesProperty([]DataFile{SimpleDataFile{"Sigfaibles_debits.csv"}})
 		assert.Equal(t, []string{"Sigfaibles_debits.csv"}, filesProperty["debit"])
 	})
 
 	t.Run("PopulateFilesProperty should contain both debits files in \"debit\" property", func(t *testing.T) {
-		filesProperty := PopulateFilesProperty([]Filename{SimpleFilename{"Sigfaibles_debits.csv"}, SimpleFilename{"Sigfaibles_debits2.csv"}})
+		filesProperty := PopulateFilesProperty([]DataFile{SimpleDataFile{"Sigfaibles_debits.csv"}, SimpleDataFile{"Sigfaibles_debits2.csv"}})
 		assert.Equal(t, []string{"Sigfaibles_debits.csv", "Sigfaibles_debits2.csv"}, filesProperty["debit"])
 	})
 
 	t.Run("Should not include unsupported files", func(t *testing.T) {
-		filesProperty := PopulateFilesProperty([]Filename{SimpleFilename{"coco.csv"}})
+		filesProperty := PopulateFilesProperty([]DataFile{SimpleDataFile{"coco.csv"}})
 		assert.Equal(t, FilesProperty{}, filesProperty)
 	})
 }
@@ -149,7 +149,7 @@ func MakeMetadata(metadataFields MetadataProperty) UploadedFileMeta {
 func TestGetFileTypeFromMetadata(t *testing.T) {
 
 	t.Run("should return \"debit\" for bin file which original name included \"debits\"", func(t *testing.T) {
-		got := GetFileTypeFromMetadata("9a047825d8173684b69994428449302f.bin", MakeMetadata(MetadataProperty{
+		got := ExtractFileTypeFromMetadata("9a047825d8173684b69994428449302f.bin", MakeMetadata(MetadataProperty{
 			"filename":  "Sigfaible_debits.csv",
 			"goup-path": "urssaf",
 		}))
@@ -157,7 +157,7 @@ func TestGetFileTypeFromMetadata(t *testing.T) {
 	})
 
 	t.Run("should return \"bdf\" for bin file which came from bdf", func(t *testing.T) {
-		got := GetFileTypeFromMetadata("60d1bd320523904d8b8b427efbbd3928.bin", MakeMetadata(MetadataProperty{
+		got := ExtractFileTypeFromMetadata("60d1bd320523904d8b8b427efbbd3928.bin", MakeMetadata(MetadataProperty{
 			"filename":  "FICHIER_SF_2020_02.csv",
 			"goup-path": "bdf",
 		}))
@@ -165,7 +165,7 @@ func TestGetFileTypeFromMetadata(t *testing.T) {
 	})
 
 	t.Run("should return \"interim\" for bin file which had a sas7dbat extension", func(t *testing.T) {
-		got := GetFileTypeFromMetadata("ab8613ab66ebddb2db21e36b92fc5b70.bin", MakeMetadata(MetadataProperty{
+		got := ExtractFileTypeFromMetadata("ab8613ab66ebddb2db21e36b92fc5b70.bin", MakeMetadata(MetadataProperty{
 			"filename":  "tab_19m10.sas7bdat",
 			"goup-path": "dgefp",
 		}))
@@ -206,7 +206,7 @@ func TestGetFileType(t *testing.T) {
 	}
 	for _, testCase := range cases {
 		t.Run("should return "+testCase.category+" for file "+testCase.name, func(t *testing.T) {
-			got := GetFileType(testCase.name)
+			got := ExtractFileTypeFromFilename(testCase.name)
 			assert.Equal(t, testCase.category, got)
 		})
 	}

--- a/main_test.go
+++ b/main_test.go
@@ -96,21 +96,21 @@ import (
 // 	})
 // }
 
-type FakeFileName struct {
+type FakeFilename struct {
 	filename string
 }
 
-func (ffn FakeFileName) GetFilenameToImport() string {
+func (ffn FakeFilename) GetFilenameToImport() string {
 	return ffn.filename
 }
 
-func (ffn FakeFileName) GetOriginalFilename() string {
+func (ffn FakeFilename) GetOriginalFilename() string {
 	return ffn.filename
 }
 
 func TestPurePrepareImport(t *testing.T) {
 	t.Run("Should return the filename in the debit property", func(t *testing.T) {
-		filename := FakeFileName{"Sigfaibles_debits.csv"}
+		filename := FakeFilename{"Sigfaibles_debits.csv"}
 
 		res := PurePrepareImport([]Filename{filename})
 		expected := AdminObject{
@@ -120,91 +120,91 @@ func TestPurePrepareImport(t *testing.T) {
 	})
 }
 
-// func TestPopulateFilesProperty(t *testing.T) {
-// 	t.Run("PopulateFilesProperty should contain effectif file in \"effectif\" property", func(t *testing.T) {
-// 		filesProperty := PopulateFilesProperty([]string{"Sigfaibles_effectif_siret.csv"}, "")
-// 		assert.Equal(t, []string{"Sigfaibles_effectif_siret.csv"}, filesProperty["effectif"])
-// 	})
+func TestPopulateFilesProperty(t *testing.T) {
+	t.Run("PopulateFilesProperty should contain effectif file in \"effectif\" property", func(t *testing.T) {
+		filesProperty := PopulateFilesProperty([]Filename{FakeFilename{"Sigfaibles_effectif_siret.csv"}})
+		assert.Equal(t, []string{"Sigfaibles_effectif_siret.csv"}, filesProperty["effectif"])
+	})
 
-// 	t.Run("PopulateFilesProperty should contain one debit file in \"debit\" property", func(t *testing.T) {
-// 		filesProperty := PopulateFilesProperty([]string{"Sigfaibles_debits.csv"}, "")
-// 		assert.Equal(t, []string{"Sigfaibles_debits.csv"}, filesProperty["debit"])
-// 	})
+	t.Run("PopulateFilesProperty should contain one debit file in \"debit\" property", func(t *testing.T) {
+		filesProperty := PopulateFilesProperty([]Filename{FakeFilename{"Sigfaibles_debits.csv"}})
+		assert.Equal(t, []string{"Sigfaibles_debits.csv"}, filesProperty["debit"])
+	})
 
-// 	t.Run("PopulateFilesProperty should contain both debits files in \"debit\" property", func(t *testing.T) {
-// 		filesProperty := PopulateFilesProperty([]string{"Sigfaibles_debits.csv", "Sigfaibles_debits2.csv"}, "")
-// 		assert.Equal(t, []string{"Sigfaibles_debits.csv", "Sigfaibles_debits2.csv"}, filesProperty["debit"])
-// 	})
+	t.Run("PopulateFilesProperty should contain both debits files in \"debit\" property", func(t *testing.T) {
+		filesProperty := PopulateFilesProperty([]Filename{FakeFilename{"Sigfaibles_debits.csv"}, FakeFilename{"Sigfaibles_debits2.csv"}})
+		assert.Equal(t, []string{"Sigfaibles_debits.csv", "Sigfaibles_debits2.csv"}, filesProperty["debit"])
+	})
 
-// 	t.Run("Should not include unsupported files", func(t *testing.T) {
-// 		filesProperty := PopulateFilesProperty([]string{"coco.csv"}, "")
-// 		assert.Equal(t, FilesProperty{}, filesProperty)
-// 	})
-// }
+	t.Run("Should not include unsupported files", func(t *testing.T) {
+		filesProperty := PopulateFilesProperty([]Filename{FakeFilename{"coco.csv"}})
+		assert.Equal(t, FilesProperty{}, filesProperty)
+	})
+}
 
-// func MakeMetadata(metadataFields MetadataProperty) UploadedFileMeta {
-// 	return UploadedFileMeta{MetaData: metadataFields}
-// }
+func MakeMetadata(metadataFields MetadataProperty) UploadedFileMeta {
+	return UploadedFileMeta{MetaData: metadataFields}
+}
 
-// func TestGetFileType(t *testing.T) {
+func TestGetFileType(t *testing.T) {
 
-// 	t.Run("should return \"debit\" for bin file which original name included \"debits\"", func(t *testing.T) {
-// 		got := GetFileTypeFromMetadata("9a047825d8173684b69994428449302f.bin", MakeMetadata(MetadataProperty{
-// 			"filename":  "Sigfaible_debits.csv",
-// 			"goup-path": "urssaf",
-// 		}))
-// 		assert.Equal(t, "debit", got)
-// 	})
+	t.Run("should return \"debit\" for bin file which original name included \"debits\"", func(t *testing.T) {
+		got := GetFileTypeFromMetadata("9a047825d8173684b69994428449302f.bin", MakeMetadata(MetadataProperty{
+			"filename":  "Sigfaible_debits.csv",
+			"goup-path": "urssaf",
+		}))
+		assert.Equal(t, "debit", got)
+	})
 
-// 	t.Run("should return \"bdf\" for bin file which came from bdf", func(t *testing.T) {
-// 		got := GetFileTypeFromMetadata("60d1bd320523904d8b8b427efbbd3928.bin", MakeMetadata(MetadataProperty{
-// 			"filename":  "FICHIER_SF_2020_02.csv",
-// 			"goup-path": "bdf",
-// 		}))
-// 		assert.Equal(t, "bdf", got)
-// 	})
+	t.Run("should return \"bdf\" for bin file which came from bdf", func(t *testing.T) {
+		got := GetFileTypeFromMetadata("60d1bd320523904d8b8b427efbbd3928.bin", MakeMetadata(MetadataProperty{
+			"filename":  "FICHIER_SF_2020_02.csv",
+			"goup-path": "bdf",
+		}))
+		assert.Equal(t, "bdf", got)
+	})
 
-// 	t.Run("should return \"interim\" for bin file which had a sas7dbat extension", func(t *testing.T) {
-// 		got := GetFileTypeFromMetadata("ab8613ab66ebddb2db21e36b92fc5b70.bin", MakeMetadata(MetadataProperty{
-// 			"filename":  "tab_19m10.sas7bdat",
-// 			"goup-path": "dgefp",
-// 		}))
-// 		assert.Equal(t, "interim", got)
-// 	})
+	t.Run("should return \"interim\" for bin file which had a sas7dbat extension", func(t *testing.T) {
+		got := GetFileTypeFromMetadata("ab8613ab66ebddb2db21e36b92fc5b70.bin", MakeMetadata(MetadataProperty{
+			"filename":  "tab_19m10.sas7bdat",
+			"goup-path": "dgefp",
+		}))
+		assert.Equal(t, "interim", got)
+	})
 
-// 	// inspired by https://github.com/golang/go/wiki/TableDrivenTests
-// 	cases := []struct {
-// 		name     string
-// 		category string
-// 	}{
-// 		// guessed from urssaf files found on stockage/goub server
-// 		{"Sigfaible_debits.csv", "debit"},
-// 		{"Sigfaible_cotisdues.csv", "cotisation"},
-// 		{"Sigfaible_pcoll.csv", "procol"},
-// 		{"Sigfaible_etablissement_utf8.csv", "admin_urssaf"},
-// 		{"Sigfaible_effectif_siret.csv", "effectif"},
-// 		{"Sigfaible_effectif_siren.csv", "effectif_ent"},
-// 		{"Sigfaible_delais.csv", "delai"},
-// 		{"Sigfaible_ccsf.csv", "ccsf"},
+	// inspired by https://github.com/golang/go/wiki/TableDrivenTests
+	cases := []struct {
+		name     string
+		category string
+	}{
+		// guessed from urssaf files found on stockage/goub server
+		{"Sigfaible_debits.csv", "debit"},
+		{"Sigfaible_cotisdues.csv", "cotisation"},
+		{"Sigfaible_pcoll.csv", "procol"},
+		{"Sigfaible_etablissement_utf8.csv", "admin_urssaf"},
+		{"Sigfaible_effectif_siret.csv", "effectif"},
+		{"Sigfaible_effectif_siren.csv", "effectif_ent"},
+		{"Sigfaible_delais.csv", "delai"},
+		{"Sigfaible_ccsf.csv", "ccsf"},
 
-// 		// guessed from dgefp files
-// 		{"act_partielle_conso_depuis2014_FRANCE.csv", "apconso"},
-// 		{"act_partielle_ddes_depuis2015_FRANCE.csv", "apdemande"},
+		// guessed from dgefp files
+		{"act_partielle_conso_depuis2014_FRANCE.csv", "apconso"},
+		{"act_partielle_ddes_depuis2015_FRANCE.csv", "apdemande"},
 
-// 		// others
-// 		{"Sigfaibles_debits.csv", "debit"},
-// 		{"Sigfaibles_debits2.csv", "debit"},
-// 		{"diane_req_2002.csv", "diane"},
-// 		{"diane_req_dom_2002.csv", "diane"},
-// 		{"effectif_dom.csv", "effectif"},
-// 		{"filter_siren_2002.csv", "filter"},
-// 		{"sireneUL.csv", "sirene_ul"},
-// 		{"StockEtablissement_utf8_geo.csv", "comptes"},
-// 	}
-// 	for _, testCase := range cases {
-// 		t.Run("should return "+testCase.category+" for file "+testCase.name, func(t *testing.T) {
-// 			got := GetFileType(testCase.name)
-// 			assert.Equal(t, testCase.category, got)
-// 		})
-// 	}
-// }
+		// others
+		{"Sigfaibles_debits.csv", "debit"},
+		{"Sigfaibles_debits2.csv", "debit"},
+		{"diane_req_2002.csv", "diane"},
+		{"diane_req_dom_2002.csv", "diane"},
+		{"effectif_dom.csv", "effectif"},
+		{"filter_siren_2002.csv", "filter"},
+		{"sireneUL.csv", "sirene_ul"},
+		{"StockEtablissement_utf8_geo.csv", "comptes"},
+	}
+	for _, testCase := range cases {
+		t.Run("should return "+testCase.category+" for file "+testCase.name, func(t *testing.T) {
+			got := GetFileType(testCase.name)
+			assert.Equal(t, testCase.category, got)
+		})
+	}
+}

--- a/main_test.go
+++ b/main_test.go
@@ -63,6 +63,22 @@ func TestPrepareImport(t *testing.T) {
 		}
 		assert.Equal(t, expected, res)
 	})
+
+	t.Run("Should use goup-path to detect file type", func(t *testing.T) {
+		dir := createTempFiles(t, "60d1bd320523904d8b8b427efbbd3928.bin")
+
+		tmpFilename := filepath.Join(dir, "60d1bd320523904d8b8b427efbbd3928.info")
+		content := []byte("{\"MetaData\":{\"filename\":\"FICHIER_SF_2020_02.csv\",\"goup-path\":\"bdf\"}}")
+		if err := ioutil.WriteFile(tmpFilename, content, 0666); err != nil {
+			t.Fatal(err.Error())
+		}
+
+		res, _ := PrepareImport(dir)
+		expected := AdminObject{
+			"files": FilesProperty{"bdf": []string{"60d1bd320523904d8b8b427efbbd3928.bin"}},
+		}
+		assert.Equal(t, expected, res)
+	})
 }
 
 func TestPurePrepareImport(t *testing.T) {

--- a/main_test.go
+++ b/main_test.go
@@ -62,40 +62,6 @@ import (
 // 	})
 // }
 
-// // Prepare import should return json object.
-// func TestOldPurePrepareImport(t *testing.T) {
-// 	t.Run("Should return a json with one file", func(t *testing.T) {
-// 		res := OldPurePrepareImport([]string{"Sigfaibles_debits.csv"}, "")
-// 		expected := AdminObject{
-// 			"files": FilesProperty{"debit": []string{"Sigfaibles_debits.csv"}},
-// 		}
-// 		assert.Equal(t, expected, res)
-// 	})
-
-// 	t.Run("Should return an empty json when there is no file", func(t *testing.T) {
-// 		res := OldPurePrepareImport([]string{}, "")
-// 		assert.Equal(t, AdminObject{"files": FilesProperty{}}, res)
-// 	})
-
-// 	t.Run("Should support multiple types of csv files", func(t *testing.T) {
-// 		files := []string{
-// 			"diane_req_2002.csv",              // --> "diane"
-// 			"diane_req_dom_2002.csv",          // --> "diane"
-// 			"effectif_dom.csv",                // --> "effectif"
-// 			"filter_siren_2002.csv",           // --> "filter"
-// 			"sireneUL.csv",                    // --> "sirene_ul"
-// 			"StockEtablissement_utf8_geo.csv", // --> "comptes"
-// 		}
-// 		res := OldPurePrepareImport(files, "")
-// 		resFilesProperty := res["files"].(FilesProperty)
-// 		resultingFiles := []string{}
-// 		for _, filenames := range resFilesProperty {
-// 			resultingFiles = append(resultingFiles, filenames...)
-// 		}
-// 		assert.Subset(t, resultingFiles, files)
-// 	})
-// }
-
 type FakeFilename struct {
 	filename string
 }
@@ -117,6 +83,33 @@ func TestPurePrepareImport(t *testing.T) {
 			"files": FilesProperty{"debit": []string{"Sigfaibles_debits.csv"}},
 		}
 		assert.Equal(t, expected, res)
+	})
+
+	t.Run("Should return an empty json when there is no file", func(t *testing.T) {
+		res := PurePrepareImport([]Filename{})
+		assert.Equal(t, AdminObject{"files": FilesProperty{}}, res)
+	})
+
+	t.Run("Should support multiple types of csv files", func(t *testing.T) {
+		files := []string{
+			"diane_req_2002.csv",              // --> "diane"
+			"diane_req_dom_2002.csv",          // --> "diane"
+			"effectif_dom.csv",                // --> "effectif"
+			"filter_siren_2002.csv",           // --> "filter"
+			"sireneUL.csv",                    // --> "sirene_ul"
+			"StockEtablissement_utf8_geo.csv", // --> "comptes"
+		}
+		augmentedFiles := []Filename{}
+		for _, file := range files {
+			augmentedFiles = append(augmentedFiles, FakeFilename{file})
+		}
+		res := PurePrepareImport(augmentedFiles)
+		resFilesProperty := res["files"].(FilesProperty)
+		resultingFiles := []string{}
+		for _, filenames := range resFilesProperty {
+			resultingFiles = append(resultingFiles, filenames...)
+		}
+		assert.Subset(t, resultingFiles, files)
 	})
 }
 

--- a/main_test.go
+++ b/main_test.go
@@ -146,7 +146,7 @@ func MakeMetadata(metadataFields MetadataProperty) UploadedFileMeta {
 	return UploadedFileMeta{MetaData: metadataFields}
 }
 
-func TestGetFileType(t *testing.T) {
+func TestGetFileTypeFromMetadata(t *testing.T) {
 
 	t.Run("should return \"debit\" for bin file which original name included \"debits\"", func(t *testing.T) {
 		got := GetFileTypeFromMetadata("9a047825d8173684b69994428449302f.bin", MakeMetadata(MetadataProperty{
@@ -171,6 +171,9 @@ func TestGetFileType(t *testing.T) {
 		}))
 		assert.Equal(t, "interim", got)
 	})
+}
+
+func TestGetFileType(t *testing.T) {
 
 	// inspired by https://github.com/golang/go/wiki/TableDrivenTests
 	cases := []struct {

--- a/main_test.go
+++ b/main_test.go
@@ -99,18 +99,23 @@ func TestOldPurePrepareImport(t *testing.T) {
 	})
 }
 
-type FakeFileName string
-
-func (ffn FakeFileName) GetFilenameToImport() string{
-  return ffn.(string)
+type FakeFileName struct {
+	filename string
 }
 
+func (ffn FakeFileName) GetFilenameToImport() string {
+	return ffn.filename
+}
+
+func (ffn FakeFileName) GetOriginalFilename() string {
+	return ffn.filename
+}
 
 func TestPurePrepareImport(t *testing.T) {
 	t.Run("Should return the filename in the debit property", func(t *testing.T) {
-    filename := Filename{}
+		filename := FakeFileName{"Sigfaibles_debits.csv"}
 
-		res := PurePrepareImport([]string{"Sigfaibles_debits.csv"})
+		res := PurePrepareImport([]Filename{filename})
 		expected := AdminObject{
 			"files": FilesProperty{"debit": []string{"Sigfaibles_debits.csv"}},
 		}

--- a/main_test.go
+++ b/main_test.go
@@ -66,9 +66,9 @@ func TestPrepareImport(t *testing.T) {
 }
 
 // Prepare import should return json object.
-func TestPurePrepareImport(t *testing.T) {
+func TestOldPurePrepareImport(t *testing.T) {
 	t.Run("Should return a json with one file", func(t *testing.T) {
-		res := PurePrepareImport([]string{"Sigfaibles_debits.csv"}, "")
+		res := OldPurePrepareImport([]string{"Sigfaibles_debits.csv"}, "")
 		expected := AdminObject{
 			"files": FilesProperty{"debit": []string{"Sigfaibles_debits.csv"}},
 		}
@@ -76,7 +76,7 @@ func TestPurePrepareImport(t *testing.T) {
 	})
 
 	t.Run("Should return an empty json when there is no file", func(t *testing.T) {
-		res := PurePrepareImport([]string{}, "")
+		res := OldPurePrepareImport([]string{}, "")
 		assert.Equal(t, AdminObject{"files": FilesProperty{}}, res)
 	})
 
@@ -89,7 +89,7 @@ func TestPurePrepareImport(t *testing.T) {
 			"sireneUL.csv",                    // --> "sirene_ul"
 			"StockEtablissement_utf8_geo.csv", // --> "comptes"
 		}
-		res := PurePrepareImport(files, "")
+		res := OldPurePrepareImport(files, "")
 		resFilesProperty := res["files"].(FilesProperty)
 		resultingFiles := []string{}
 		for _, filenames := range resFilesProperty {

--- a/main_test.go
+++ b/main_test.go
@@ -1,103 +1,100 @@
 package main
 
 import (
-	"io/ioutil"
-	"os"
-	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
 
-// Helper to create temporary files, and clean up after the execution of tests
-func createTempFiles(t *testing.T, filename string) string {
-	t.Helper()
-	dir, err := ioutil.TempDir(os.TempDir(), "example")
-	if err != nil {
-		t.Fatal(err.Error())
-	}
-	t.Cleanup(func() { os.RemoveAll(dir) })
+// // Helper to create temporary files, and clean up after the execution of tests
+// func createTempFiles(t *testing.T, filename string) string {
+// 	t.Helper()
+// 	dir, err := ioutil.TempDir(os.TempDir(), "example")
+// 	if err != nil {
+// 		t.Fatal(err.Error())
+// 	}
+// 	t.Cleanup(func() { os.RemoveAll(dir) })
 
-	tmpFilename := filepath.Join(dir, filename)
-	if err := ioutil.WriteFile(tmpFilename, []byte{}, 0666); err != nil {
-		t.Fatal(err.Error())
-	}
+// 	tmpFilename := filepath.Join(dir, filename)
+// 	if err := ioutil.WriteFile(tmpFilename, []byte{}, 0666); err != nil {
+// 		t.Fatal(err.Error())
+// 	}
 
-	return dir
-}
+// 	return dir
+// }
 
-// Test: ReadFilenames should return filenames in a directory
-func TestReadFilenames(t *testing.T) {
-	t.Run("Should return filenames in a directory", func(t *testing.T) {
-		dir := createTempFiles(t, "tmpfile")
-		filenames, err := ReadFilenames(dir)
-		if err != nil {
-			t.Fatal(err.Error())
-		}
-		assert.Equal(t, []string{"tmpfile"}, filenames)
-	})
-}
+// // Test: ReadFilenames should return filenames in a directory
+// func TestReadFilenames(t *testing.T) {
+// 	t.Run("Should return filenames in a directory", func(t *testing.T) {
+// 		dir := createTempFiles(t, "tmpfile")
+// 		filenames, err := ReadFilenames(dir)
+// 		if err != nil {
+// 			t.Fatal(err.Error())
+// 		}
+// 		assert.Equal(t, []string{"tmpfile"}, filenames)
+// 	})
+// }
 
-func TestPrepareImport(t *testing.T) {
-	t.Run("Should return a json with one file", func(t *testing.T) {
-		dir := createTempFiles(t, "Sigfaibles_debits.csv")
-		res, _ := PrepareImport(dir)
-		expected := AdminObject{
-			"files": FilesProperty{"debit": []string{"Sigfaibles_debits.csv"}},
-		}
-		assert.Equal(t, expected, res)
-	})
+// func TestPrepareImport(t *testing.T) {
+// 	t.Run("Should return a json with one file", func(t *testing.T) {
+// 		dir := createTempFiles(t, "Sigfaibles_debits.csv")
+// 		res, _ := PrepareImport(dir)
+// 		expected := AdminObject{
+// 			"files": FilesProperty{"debit": []string{"Sigfaibles_debits.csv"}},
+// 		}
+// 		assert.Equal(t, expected, res)
+// 	})
 
-	t.Run("Should support uploaded files (bin+info)", func(t *testing.T) {
-		dir := createTempFiles(t, "9a047825d8173684b69994428449302f.bin")
+// 	t.Run("Should support uploaded files (bin+info)", func(t *testing.T) {
+// 		dir := createTempFiles(t, "9a047825d8173684b69994428449302f.bin")
 
-		tmpFilename := filepath.Join(dir, "9a047825d8173684b69994428449302f.info")
-		content := []byte("{\"MetaData\":{\"filename\":\"Sigfaible_debits.csv\",\"goup-path\":\"urssaf\"}}")
-		if err := ioutil.WriteFile(tmpFilename, content, 0666); err != nil {
-			t.Fatal(err.Error())
-		}
+// 		tmpFilename := filepath.Join(dir, "9a047825d8173684b69994428449302f.info")
+// 		content := []byte("{\"MetaData\":{\"filename\":\"Sigfaible_debits.csv\",\"goup-path\":\"urssaf\"}}")
+// 		if err := ioutil.WriteFile(tmpFilename, content, 0666); err != nil {
+// 			t.Fatal(err.Error())
+// 		}
 
-		res, _ := PrepareImport(dir)
-		expected := AdminObject{
-			"files": FilesProperty{"debit": []string{"9a047825d8173684b69994428449302f.bin"}},
-		}
-		assert.Equal(t, expected, res)
-	})
-}
+// 		res, _ := PrepareImport(dir)
+// 		expected := AdminObject{
+// 			"files": FilesProperty{"debit": []string{"9a047825d8173684b69994428449302f.bin"}},
+// 		}
+// 		assert.Equal(t, expected, res)
+// 	})
+// }
 
-// Prepare import should return json object.
-func TestOldPurePrepareImport(t *testing.T) {
-	t.Run("Should return a json with one file", func(t *testing.T) {
-		res := OldPurePrepareImport([]string{"Sigfaibles_debits.csv"}, "")
-		expected := AdminObject{
-			"files": FilesProperty{"debit": []string{"Sigfaibles_debits.csv"}},
-		}
-		assert.Equal(t, expected, res)
-	})
+// // Prepare import should return json object.
+// func TestOldPurePrepareImport(t *testing.T) {
+// 	t.Run("Should return a json with one file", func(t *testing.T) {
+// 		res := OldPurePrepareImport([]string{"Sigfaibles_debits.csv"}, "")
+// 		expected := AdminObject{
+// 			"files": FilesProperty{"debit": []string{"Sigfaibles_debits.csv"}},
+// 		}
+// 		assert.Equal(t, expected, res)
+// 	})
 
-	t.Run("Should return an empty json when there is no file", func(t *testing.T) {
-		res := OldPurePrepareImport([]string{}, "")
-		assert.Equal(t, AdminObject{"files": FilesProperty{}}, res)
-	})
+// 	t.Run("Should return an empty json when there is no file", func(t *testing.T) {
+// 		res := OldPurePrepareImport([]string{}, "")
+// 		assert.Equal(t, AdminObject{"files": FilesProperty{}}, res)
+// 	})
 
-	t.Run("Should support multiple types of csv files", func(t *testing.T) {
-		files := []string{
-			"diane_req_2002.csv",              // --> "diane"
-			"diane_req_dom_2002.csv",          // --> "diane"
-			"effectif_dom.csv",                // --> "effectif"
-			"filter_siren_2002.csv",           // --> "filter"
-			"sireneUL.csv",                    // --> "sirene_ul"
-			"StockEtablissement_utf8_geo.csv", // --> "comptes"
-		}
-		res := OldPurePrepareImport(files, "")
-		resFilesProperty := res["files"].(FilesProperty)
-		resultingFiles := []string{}
-		for _, filenames := range resFilesProperty {
-			resultingFiles = append(resultingFiles, filenames...)
-		}
-		assert.Subset(t, resultingFiles, files)
-	})
-}
+// 	t.Run("Should support multiple types of csv files", func(t *testing.T) {
+// 		files := []string{
+// 			"diane_req_2002.csv",              // --> "diane"
+// 			"diane_req_dom_2002.csv",          // --> "diane"
+// 			"effectif_dom.csv",                // --> "effectif"
+// 			"filter_siren_2002.csv",           // --> "filter"
+// 			"sireneUL.csv",                    // --> "sirene_ul"
+// 			"StockEtablissement_utf8_geo.csv", // --> "comptes"
+// 		}
+// 		res := OldPurePrepareImport(files, "")
+// 		resFilesProperty := res["files"].(FilesProperty)
+// 		resultingFiles := []string{}
+// 		for _, filenames := range resFilesProperty {
+// 			resultingFiles = append(resultingFiles, filenames...)
+// 		}
+// 		assert.Subset(t, resultingFiles, files)
+// 	})
+// }
 
 type FakeFileName struct {
 	filename string
@@ -123,91 +120,91 @@ func TestPurePrepareImport(t *testing.T) {
 	})
 }
 
-func TestPopulateFilesProperty(t *testing.T) {
-	t.Run("PopulateFilesProperty should contain effectif file in \"effectif\" property", func(t *testing.T) {
-		filesProperty := PopulateFilesProperty([]string{"Sigfaibles_effectif_siret.csv"}, "")
-		assert.Equal(t, []string{"Sigfaibles_effectif_siret.csv"}, filesProperty["effectif"])
-	})
+// func TestPopulateFilesProperty(t *testing.T) {
+// 	t.Run("PopulateFilesProperty should contain effectif file in \"effectif\" property", func(t *testing.T) {
+// 		filesProperty := PopulateFilesProperty([]string{"Sigfaibles_effectif_siret.csv"}, "")
+// 		assert.Equal(t, []string{"Sigfaibles_effectif_siret.csv"}, filesProperty["effectif"])
+// 	})
 
-	t.Run("PopulateFilesProperty should contain one debit file in \"debit\" property", func(t *testing.T) {
-		filesProperty := PopulateFilesProperty([]string{"Sigfaibles_debits.csv"}, "")
-		assert.Equal(t, []string{"Sigfaibles_debits.csv"}, filesProperty["debit"])
-	})
+// 	t.Run("PopulateFilesProperty should contain one debit file in \"debit\" property", func(t *testing.T) {
+// 		filesProperty := PopulateFilesProperty([]string{"Sigfaibles_debits.csv"}, "")
+// 		assert.Equal(t, []string{"Sigfaibles_debits.csv"}, filesProperty["debit"])
+// 	})
 
-	t.Run("PopulateFilesProperty should contain both debits files in \"debit\" property", func(t *testing.T) {
-		filesProperty := PopulateFilesProperty([]string{"Sigfaibles_debits.csv", "Sigfaibles_debits2.csv"}, "")
-		assert.Equal(t, []string{"Sigfaibles_debits.csv", "Sigfaibles_debits2.csv"}, filesProperty["debit"])
-	})
+// 	t.Run("PopulateFilesProperty should contain both debits files in \"debit\" property", func(t *testing.T) {
+// 		filesProperty := PopulateFilesProperty([]string{"Sigfaibles_debits.csv", "Sigfaibles_debits2.csv"}, "")
+// 		assert.Equal(t, []string{"Sigfaibles_debits.csv", "Sigfaibles_debits2.csv"}, filesProperty["debit"])
+// 	})
 
-	t.Run("Should not include unsupported files", func(t *testing.T) {
-		filesProperty := PopulateFilesProperty([]string{"coco.csv"}, "")
-		assert.Equal(t, FilesProperty{}, filesProperty)
-	})
-}
+// 	t.Run("Should not include unsupported files", func(t *testing.T) {
+// 		filesProperty := PopulateFilesProperty([]string{"coco.csv"}, "")
+// 		assert.Equal(t, FilesProperty{}, filesProperty)
+// 	})
+// }
 
-func MakeMetadata(metadataFields MetadataProperty) UploadedFileMeta {
-	return UploadedFileMeta{MetaData: metadataFields}
-}
+// func MakeMetadata(metadataFields MetadataProperty) UploadedFileMeta {
+// 	return UploadedFileMeta{MetaData: metadataFields}
+// }
 
-func TestGetFileType(t *testing.T) {
+// func TestGetFileType(t *testing.T) {
 
-	t.Run("should return \"debit\" for bin file which original name included \"debits\"", func(t *testing.T) {
-		got := GetFileTypeFromMetadata("9a047825d8173684b69994428449302f.bin", MakeMetadata(MetadataProperty{
-			"filename":  "Sigfaible_debits.csv",
-			"goup-path": "urssaf",
-		}))
-		assert.Equal(t, "debit", got)
-	})
+// 	t.Run("should return \"debit\" for bin file which original name included \"debits\"", func(t *testing.T) {
+// 		got := GetFileTypeFromMetadata("9a047825d8173684b69994428449302f.bin", MakeMetadata(MetadataProperty{
+// 			"filename":  "Sigfaible_debits.csv",
+// 			"goup-path": "urssaf",
+// 		}))
+// 		assert.Equal(t, "debit", got)
+// 	})
 
-	t.Run("should return \"bdf\" for bin file which came from bdf", func(t *testing.T) {
-		got := GetFileTypeFromMetadata("60d1bd320523904d8b8b427efbbd3928.bin", MakeMetadata(MetadataProperty{
-			"filename":  "FICHIER_SF_2020_02.csv",
-			"goup-path": "bdf",
-		}))
-		assert.Equal(t, "bdf", got)
-	})
+// 	t.Run("should return \"bdf\" for bin file which came from bdf", func(t *testing.T) {
+// 		got := GetFileTypeFromMetadata("60d1bd320523904d8b8b427efbbd3928.bin", MakeMetadata(MetadataProperty{
+// 			"filename":  "FICHIER_SF_2020_02.csv",
+// 			"goup-path": "bdf",
+// 		}))
+// 		assert.Equal(t, "bdf", got)
+// 	})
 
-	t.Run("should return \"interim\" for bin file which had a sas7dbat extension", func(t *testing.T) {
-		got := GetFileTypeFromMetadata("ab8613ab66ebddb2db21e36b92fc5b70.bin", MakeMetadata(MetadataProperty{
-			"filename":  "tab_19m10.sas7bdat",
-			"goup-path": "dgefp",
-		}))
-		assert.Equal(t, "interim", got)
-	})
+// 	t.Run("should return \"interim\" for bin file which had a sas7dbat extension", func(t *testing.T) {
+// 		got := GetFileTypeFromMetadata("ab8613ab66ebddb2db21e36b92fc5b70.bin", MakeMetadata(MetadataProperty{
+// 			"filename":  "tab_19m10.sas7bdat",
+// 			"goup-path": "dgefp",
+// 		}))
+// 		assert.Equal(t, "interim", got)
+// 	})
 
-	// inspired by https://github.com/golang/go/wiki/TableDrivenTests
-	cases := []struct {
-		name     string
-		category string
-	}{
-		// guessed from urssaf files found on stockage/goub server
-		{"Sigfaible_debits.csv", "debit"},
-		{"Sigfaible_cotisdues.csv", "cotisation"},
-		{"Sigfaible_pcoll.csv", "procol"},
-		{"Sigfaible_etablissement_utf8.csv", "admin_urssaf"},
-		{"Sigfaible_effectif_siret.csv", "effectif"},
-		{"Sigfaible_effectif_siren.csv", "effectif_ent"},
-		{"Sigfaible_delais.csv", "delai"},
-		{"Sigfaible_ccsf.csv", "ccsf"},
+// 	// inspired by https://github.com/golang/go/wiki/TableDrivenTests
+// 	cases := []struct {
+// 		name     string
+// 		category string
+// 	}{
+// 		// guessed from urssaf files found on stockage/goub server
+// 		{"Sigfaible_debits.csv", "debit"},
+// 		{"Sigfaible_cotisdues.csv", "cotisation"},
+// 		{"Sigfaible_pcoll.csv", "procol"},
+// 		{"Sigfaible_etablissement_utf8.csv", "admin_urssaf"},
+// 		{"Sigfaible_effectif_siret.csv", "effectif"},
+// 		{"Sigfaible_effectif_siren.csv", "effectif_ent"},
+// 		{"Sigfaible_delais.csv", "delai"},
+// 		{"Sigfaible_ccsf.csv", "ccsf"},
 
-		// guessed from dgefp files
-		{"act_partielle_conso_depuis2014_FRANCE.csv", "apconso"},
-		{"act_partielle_ddes_depuis2015_FRANCE.csv", "apdemande"},
+// 		// guessed from dgefp files
+// 		{"act_partielle_conso_depuis2014_FRANCE.csv", "apconso"},
+// 		{"act_partielle_ddes_depuis2015_FRANCE.csv", "apdemande"},
 
-		// others
-		{"Sigfaibles_debits.csv", "debit"},
-		{"Sigfaibles_debits2.csv", "debit"},
-		{"diane_req_2002.csv", "diane"},
-		{"diane_req_dom_2002.csv", "diane"},
-		{"effectif_dom.csv", "effectif"},
-		{"filter_siren_2002.csv", "filter"},
-		{"sireneUL.csv", "sirene_ul"},
-		{"StockEtablissement_utf8_geo.csv", "comptes"},
-	}
-	for _, testCase := range cases {
-		t.Run("should return "+testCase.category+" for file "+testCase.name, func(t *testing.T) {
-			got := GetFileType(testCase.name)
-			assert.Equal(t, testCase.category, got)
-		})
-	}
-}
+// 		// others
+// 		{"Sigfaibles_debits.csv", "debit"},
+// 		{"Sigfaibles_debits2.csv", "debit"},
+// 		{"diane_req_2002.csv", "diane"},
+// 		{"diane_req_dom_2002.csv", "diane"},
+// 		{"effectif_dom.csv", "effectif"},
+// 		{"filter_siren_2002.csv", "filter"},
+// 		{"sireneUL.csv", "sirene_ul"},
+// 		{"StockEtablissement_utf8_geo.csv", "comptes"},
+// 	}
+// 	for _, testCase := range cases {
+// 		t.Run("should return "+testCase.category+" for file "+testCase.name, func(t *testing.T) {
+// 			got := GetFileType(testCase.name)
+// 			assert.Equal(t, testCase.category, got)
+// 		})
+// 	}
+// }

--- a/main_test.go
+++ b/main_test.go
@@ -99,6 +99,25 @@ func TestOldPurePrepareImport(t *testing.T) {
 	})
 }
 
+type FakeFileName string
+
+func (ffn FakeFileName) GetFilenameToImport() string{
+  return ffn.(string)
+}
+
+
+func TestPurePrepareImport(t *testing.T) {
+	t.Run("Should return the filename in the debit property", func(t *testing.T) {
+    filename := Filename{}
+
+		res := PurePrepareImport([]string{"Sigfaibles_debits.csv"})
+		expected := AdminObject{
+			"files": FilesProperty{"debit": []string{"Sigfaibles_debits.csv"}},
+		}
+		assert.Equal(t, expected, res)
+	})
+}
+
 func TestPopulateFilesProperty(t *testing.T) {
 	t.Run("PopulateFilesProperty should contain effectif file in \"effectif\" property", func(t *testing.T) {
 		filesProperty := PopulateFilesProperty([]string{"Sigfaibles_effectif_siret.csv"}, "")

--- a/main_test.go
+++ b/main_test.go
@@ -26,17 +26,17 @@ func createTempFiles(t *testing.T, filename string) string {
 	return dir
 }
 
-// // Test: ReadFilenames should return filenames in a directory
-// func TestReadFilenames(t *testing.T) {
-// 	t.Run("Should return filenames in a directory", func(t *testing.T) {
-// 		dir := createTempFiles(t, "tmpfile")
-// 		filenames, err := ReadFilenames(dir)
-// 		if err != nil {
-// 			t.Fatal(err.Error())
-// 		}
-// 		assert.Equal(t, []string{"tmpfile"}, filenames)
-// 	})
-// }
+// Test: ReadFilenames should return filenames in a directory
+func TestReadFilenames(t *testing.T) {
+	t.Run("Should return filenames in a directory", func(t *testing.T) {
+		dir := createTempFiles(t, "tmpfile")
+		filenames, err := ReadFilenames(dir)
+		if err != nil {
+			t.Fatal(err.Error())
+		}
+		assert.Equal(t, []string{"tmpfile"}, filenames)
+	})
+}
 
 func TestPrepareImport(t *testing.T) {
 	t.Run("Should return a json with one file", func(t *testing.T) {

--- a/signauxfaiblesTypes.go
+++ b/signauxfaiblesTypes.go
@@ -1,0 +1,64 @@
+package main
+
+import (
+  "regexp"
+  "strings"
+)
+
+var hasDianePrefix = regexp.MustCompile(`^diane`)
+var mentionsEffectif = regexp.MustCompile(`effectif_`)
+var mentionsDebits = regexp.MustCompile(`_debits`)
+var hasFilterPrefix = regexp.MustCompile(`^filter_`)
+
+type MetadataProperty map[string]string
+
+type UploadedFileMeta struct {
+	MetaData MetadataProperty
+}
+
+func ExtractFileTypeFromMetadata(filename string, fileinfo UploadedFileMeta) string {
+	metadata := fileinfo.MetaData
+	if metadata["goup-path"] == "bdf" {
+		return "bdf"
+	} else {
+		return ExtractFileTypeFromFilename(metadata["filename"])
+	}
+}
+
+// ExtractFileTypeFromFilename returns a file type from filename, or empty string for unsupported file names
+func ExtractFileTypeFromFilename(filename string) string {
+	switch {
+	case filename == "act_partielle_conso_depuis2014_FRANCE.csv":
+		return "apconso"
+	case filename == "act_partielle_ddes_depuis2015_FRANCE.csv":
+		return "apdemande"
+	case filename == "Sigfaible_etablissement_utf8.csv":
+		return "admin_urssaf"
+	case filename == "Sigfaible_effectif_siren.csv":
+		return "effectif_ent"
+	case filename == "Sigfaible_pcoll.csv":
+		return "procol"
+	case filename == "Sigfaible_cotisdues.csv":
+		return "cotisation"
+	case filename == "Sigfaible_delais.csv":
+		return "delai"
+	case filename == "Sigfaible_ccsf.csv":
+		return "ccsf"
+	case filename == "sireneUL.csv":
+		return "sirene_ul"
+	case filename == "StockEtablissement_utf8_geo.csv":
+		return "comptes"
+	case strings.HasSuffix(filename, ".sas7bdat"):
+		return "interim"
+	case mentionsDebits.MatchString(filename):
+		return "debit"
+	case hasDianePrefix.MatchString(filename):
+		return "diane"
+	case mentionsEffectif.MatchString(filename):
+		return "effectif"
+	case hasFilterPrefix.MatchString(filename):
+		return "filter"
+	default:
+		return ""
+	}
+}


### PR DESCRIPTION
Création d'une interface `DataFile`, qui contient une méthode `DetectFileType`