### PR TITLE
refactor: réduction de complexité + commentaires

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,13 @@
+.DEFAULT_GOAL := help
+
+install: ## Install dependencies (including development/testing dependencies)
+	@go get -t ./...
+
+format: ## Fix the formatting of .go files
+	@go fmt
+
+help: ## This help.
+	@echo 'Available targets:'
+	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z_-]+:.*?## / {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}' $(MAKEFILE_LIST)
+
+.PHONY: help install format

--- a/main.go
+++ b/main.go
@@ -11,7 +11,7 @@ import (
 	"io/ioutil"
 )
 
-// Implementation of the prepare-import command
+// Implementation of the prepare-import command.
 func main() {
 	var path = flag.String("path", ".", "Chemin d'accès aux fichiers données")
 	flag.Parse()
@@ -26,19 +26,19 @@ func main() {
 	fmt.Println(string(json))
 }
 
-// AdminObject represents a document going to be stored in the Admin db collection
+// AdminObject represents a document going to be stored in the Admin db collection.
 type AdminObject map[string]interface{}
 
-// FilesProperty represents the "files" property of an Admin object
+// FilesProperty represents the "files" property of an Admin object.
 type FilesProperty map[string][]string
 
-// DataFile represents a Data File to be imported, and allows to determine its type and name
+// DataFile represents a Data File to be imported, and allows to determine its type and name.
 type DataFile interface {
 	GetFilename() string    // the name as it will be stored in Admin
 	DetectFileType() string // returns the type of that file (e.g. "debit")
 }
 
-// SimpleDataFile is a DataFile which type can be determined without requiring a metadata file (e.g. well-named csv file)
+// SimpleDataFile is a DataFile which type can be determined without requiring a metadata file (e.g. well-named csv file).
 type SimpleDataFile struct {
 	filename string
 }
@@ -51,7 +51,7 @@ func (dataFile SimpleDataFile) GetFilename() string {
 	return dataFile.filename
 }
 
-// UploadedDataFile is a DataFile which type can be determined thanks to a metadata file (e.g. bin+info files)
+// UploadedDataFile is a DataFile which type can be determined thanks to a metadata file (e.g. bin+info files).
 type UploadedDataFile struct {
 	filename string
 	path     string
@@ -70,7 +70,7 @@ func (dataFile UploadedDataFile) GetFilename() string {
 	return dataFile.filename
 }
 
-// AugmentDataFile returns a SimpleDataFile or UploadedDataFile (if metadata had to be loaded)
+// AugmentDataFile returns a SimpleDataFile or UploadedDataFile (if metadata had to be loaded).
 func AugmentDataFile(file string, pathname string) DataFile {
 	if strings.HasSuffix(file, ".bin") {
 		return UploadedDataFile{file, pathname}
@@ -78,7 +78,7 @@ func AugmentDataFile(file string, pathname string) DataFile {
 	return SimpleDataFile{file}
 }
 
-// PrepareImport generates an Admin object from files found at given pathname of the file system
+// PrepareImport generates an Admin object from files found at given pathname of the file system.
 func PrepareImport(pathname string) (AdminObject, error) {
 	filenames, err := ReadFilenames(pathname)
 	if err != nil {
@@ -91,13 +91,13 @@ func PrepareImport(pathname string) (AdminObject, error) {
 	return PurePrepareImport(augmentedFiles), nil
 }
 
-// PurePrepareImport populates an AdminObject, given a list of data files
+// PurePrepareImport populates an AdminObject, given a list of data files.
 func PurePrepareImport(augmentedFilenames []DataFile) AdminObject {
 	filesProperty := PopulateFilesProperty(augmentedFilenames)
 	return AdminObject{"files": filesProperty}
 }
 
-// ReadFilenames returns the name of files found at the provided path
+// ReadFilenames returns the name of files found at the provided path.
 func ReadFilenames(path string) ([]string, error) {
 	var files []string
 	fileInfo, err := ioutil.ReadDir(path)
@@ -110,7 +110,7 @@ func ReadFilenames(path string) ([]string, error) {
 	return files, nil
 }
 
-// LoadMetadata returns the metadata of a .bin file, by reading the given .info file
+// LoadMetadata returns the metadata of a .bin file, by reading the given .info file.
 func LoadMetadata(filepath string) (UploadedFileMeta, error) {
 
 	// read file
@@ -129,7 +129,7 @@ func LoadMetadata(filepath string) (UploadedFileMeta, error) {
 	return uploadedFileMeta, nil
 }
 
-// PopulateFilesProperty populates the "files" property of an Admin object, given a list of Data files
+// PopulateFilesProperty populates the "files" property of an Admin object, given a list of Data files.
 func PopulateFilesProperty(filenames []DataFile) FilesProperty {
 	filesProperty := FilesProperty{}
 	for _, filename := range filenames {

--- a/main.go
+++ b/main.go
@@ -74,9 +74,8 @@ func (dataFile UploadedDataFile) GetFilename() string {
 func AugmentDataFile(file string, pathname string) DataFile {
 	if strings.HasSuffix(file, ".bin") {
 		return UploadedDataFile{file, pathname}
-	} else {
-		return SimpleDataFile{file}
 	}
+	return SimpleDataFile{file}
 }
 
 // PrepareImport generates an Admin object from files found at given pathname of the file system

--- a/main.go
+++ b/main.go
@@ -11,6 +11,7 @@ import (
 	"io/ioutil"
 )
 
+// Implementation of the prepare-import command
 func main() {
 	var path = flag.String("path", ".", "Chemin d'accès aux fichiers données")
 	flag.Parse()
@@ -25,13 +26,19 @@ func main() {
 	fmt.Println(string(json))
 }
 
+// Type of the Admin object (as stored in the database)
 type AdminObject map[string]interface{}
 
+// Type of the "files" property of an Admin object
+type FilesProperty map[string][]string
+
+// Interface representing a Data File, and allows to determine its type and name
 type DataFile interface {
-	GetFilename() string // the name as it will be stored in Admin
-	DetectFileType() string
+	GetFilename() string    // the name as it will be stored in Admin
+	DetectFileType() string // returns the type of that file (e.g. "debit")
 }
 
+// DataFile which type can be determined without requiring a metadata file (e.g. well-named csv file)
 type SimpleDataFile struct {
 	filename string
 }
@@ -44,6 +51,7 @@ func (dataFile SimpleDataFile) GetFilename() string {
 	return dataFile.filename
 }
 
+// DataFile which type can be determined thanks to a metadata file (e.g. bin+info files)
 type UploadedDataFile struct {
 	filename string
 	path     string
@@ -55,14 +63,23 @@ func (dataFile UploadedDataFile) DetectFileType() string {
 	if err != nil {
 		log.Fatal(err)
 	}
-	filetype := ExtractFileTypeFromMetadata(metaFilepath, fileinfo)
-	return filetype // e.g. "Sigfaible_debits.csv"
+	return ExtractFileTypeFromMetadata(metaFilepath, fileinfo) // e.g. "Sigfaible_debits.csv"
 }
 
 func (dataFile UploadedDataFile) GetFilename() string {
 	return dataFile.filename
 }
 
+// Returns a SimpleDataFile or UploadedDataFile (if metadata had to be loaded)
+func AugmentDataFile(file string, pathname string) DataFile {
+	if strings.HasSuffix(file, ".bin") {
+		return UploadedDataFile{file, pathname}
+	} else {
+		return SimpleDataFile{file}
+	}
+}
+
+// Generates an Admin object from files found at given pathname of the file system
 func PrepareImport(pathname string) (AdminObject, error) {
 	filenames, err := ReadFilenames(pathname)
 	if err != nil {
@@ -70,22 +87,18 @@ func PrepareImport(pathname string) (AdminObject, error) {
 	}
 	augmentedFiles := []DataFile{}
 	for _, file := range filenames {
-		var filename DataFile
-		if strings.HasSuffix(file, ".bin") {
-			filename = UploadedDataFile{file, pathname}
-		} else {
-			filename = SimpleDataFile{file}
-		}
-		augmentedFiles = append(augmentedFiles, filename)
+		augmentedFiles = append(augmentedFiles, AugmentDataFile(file, pathname))
 	}
 	return PurePrepareImport(augmentedFiles), nil
 }
 
+// Populates an AdminObject, given a list of data files
 func PurePrepareImport(augmentedFilenames []DataFile) AdminObject {
 	filesProperty := PopulateFilesProperty(augmentedFilenames)
 	return AdminObject{"files": filesProperty}
 }
 
+// Returns the name of files found at the provided path
 func ReadFilenames(path string) ([]string, error) {
 	var files []string
 	fileInfo, err := ioutil.ReadDir(path)
@@ -98,8 +111,7 @@ func ReadFilenames(path string) ([]string, error) {
 	return files, nil
 }
 
-type FilesProperty map[string][]string
-
+// Returns the metadata of a .bin file, from the given .info file.
 func LoadMetadata(filepath string) (UploadedFileMeta, error) {
 
 	// read file
@@ -118,6 +130,7 @@ func LoadMetadata(filepath string) (UploadedFileMeta, error) {
 	return uploadedFileMeta, nil
 }
 
+// Populates the "files" property of an Admin object, given a list of Data files
 func PopulateFilesProperty(filenames []DataFile) FilesProperty {
 	filesProperty := FilesProperty{}
 	for _, filename := range filenames {

--- a/main_test.go
+++ b/main_test.go
@@ -26,7 +26,6 @@ func createTempFiles(t *testing.T, filename string) string {
 	return dir
 }
 
-// Test: ReadFilenames should return filenames in a directory
 func TestReadFilenames(t *testing.T) {
 	t.Run("Should return filenames in a directory", func(t *testing.T) {
 		dir := createTempFiles(t, "tmpfile")

--- a/signauxfaiblesTypes.go
+++ b/signauxfaiblesTypes.go
@@ -1,8 +1,8 @@
 package main
 
 import (
-  "regexp"
-  "strings"
+	"regexp"
+	"strings"
 )
 
 var hasDianePrefix = regexp.MustCompile(`^diane`)


### PR DESCRIPTION
cf https://github.com/signaux-faibles/prepare-import/pull/12/files#r401497105

... et en bonus: un Makefile qui fournit notamment une commande pour (re)formatter le code.

```sh
$ make format
```