### PR TITLE
feat: Gestion d'erreurs

### DIFF
--- a/main.go
+++ b/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"encoding/json"
-	"errors"
 	"flag"
 	"fmt"
 	"log"
@@ -72,7 +71,11 @@ func (dataFile UploadedDataFile) GetFilename() string {
 }
 
 type UnsupportedFilesError struct {
-	unsupportedFiles []string
+	UnsupportedFiles []string
+}
+
+func (err UnsupportedFilesError) Error() string {
+	return "unsupported: " + strings.Join(err.UnsupportedFiles, ", ")
 }
 
 // ReadFilenames returns the name of files found at the provided path.
@@ -112,11 +115,11 @@ func PrepareImport(pathname string) (AdminObject, error) {
 // PurePrepareImport populates an AdminObject, given a list of data files.
 func PurePrepareImport(augmentedFilenames []DataFile) (AdminObject, error) {
 	filesProperty, unsupportedFiles := PopulateFilesProperty(augmentedFilenames)
-	var errMsg string
+	var err UnsupportedFilesError
 	if unsupportedFiles != nil {
-		errMsg = "unsupported: " + strings.Join(unsupportedFiles, ", ")
+		err = UnsupportedFilesError{unsupportedFiles}
 	}
-	return AdminObject{"files": filesProperty}, errors.New(errMsg)
+	return AdminObject{"files": filesProperty}, err
 }
 
 // LoadMetadata returns the metadata of a .bin file, by reading the given .info file.

--- a/main.go
+++ b/main.go
@@ -93,7 +93,8 @@ func PrepareImport(pathname string) (AdminObject, error) {
 
 // PurePrepareImport populates an AdminObject, given a list of data files.
 func PurePrepareImport(augmentedFilenames []DataFile) AdminObject {
-	filesProperty := PopulateFilesProperty(augmentedFilenames)
+	filesProperty, _ := PopulateFilesProperty(augmentedFilenames)
+	// TODO deal with returned unsupported files
 	return AdminObject{"files": filesProperty}
 }
 
@@ -130,13 +131,14 @@ func LoadMetadata(filepath string) (UploadedFileMeta, error) {
 }
 
 // PopulateFilesProperty populates the "files" property of an Admin object, given a list of Data files.
-func PopulateFilesProperty(filenames []DataFile) FilesProperty {
+func PopulateFilesProperty(filenames []DataFile) (FilesProperty, []string) {
 	filesProperty := FilesProperty{}
+	unsupportedFiles := []string{}
 	for _, filename := range filenames {
 		filetype := filename.DetectFileType()
 
 		if filetype == "" {
-			// Unsupported file
+			unsupportedFiles = append(unsupportedFiles, filename.GetFilename())
 			continue
 		}
 		if _, exists := filesProperty[filetype]; !exists {
@@ -144,5 +146,5 @@ func PopulateFilesProperty(filenames []DataFile) FilesProperty {
 		}
 		filesProperty[filetype] = append(filesProperty[filetype], filename.GetFilename())
 	}
-	return filesProperty
+	return filesProperty, unsupportedFiles
 }

--- a/main.go
+++ b/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
 	"log"
@@ -88,14 +89,17 @@ func PrepareImport(pathname string) (AdminObject, error) {
 	for _, file := range filenames {
 		augmentedFiles = append(augmentedFiles, AugmentDataFile(file, pathname))
 	}
-	return PurePrepareImport(augmentedFiles), nil
+	return PurePrepareImport(augmentedFiles)
 }
 
 // PurePrepareImport populates an AdminObject, given a list of data files.
-func PurePrepareImport(augmentedFilenames []DataFile) AdminObject {
-	filesProperty, _ := PopulateFilesProperty(augmentedFilenames)
-	// TODO deal with returned unsupported files
-	return AdminObject{"files": filesProperty}
+func PurePrepareImport(augmentedFilenames []DataFile) (AdminObject, error) {
+	filesProperty, unsupportedFiles := PopulateFilesProperty(augmentedFilenames)
+	var errMsg string
+	if unsupportedFiles != nil {
+		errMsg = "unsupported: " + strings.Join(unsupportedFiles, ", ")
+	}
+	return AdminObject{"files": filesProperty}, errors.New(errMsg)
 }
 
 // ReadFilenames returns the name of files found at the provided path.

--- a/main.go
+++ b/main.go
@@ -59,10 +59,7 @@ type UploadedDataFile struct {
 
 func (dataFile UploadedDataFile) DetectFileType() string {
 	metaFilepath := filepath.Join(dataFile.path, strings.Replace(dataFile.filename, ".bin", ".info", 1))
-	fileinfo, err := LoadMetadata(metaFilepath)
-	if err != nil {
-		panic(err)
-	}
+	fileinfo := LoadMetadata(metaFilepath)
 	return ExtractFileTypeFromMetadata(metaFilepath, fileinfo) // e.g. "Sigfaible_debits.csv"
 }
 
@@ -123,22 +120,22 @@ func PurePrepareImport(augmentedFilenames []DataFile) (AdminObject, error) {
 }
 
 // LoadMetadata returns the metadata of a .bin file, by reading the given .info file.
-func LoadMetadata(filepath string) (UploadedFileMeta, error) {
+func LoadMetadata(filepath string) UploadedFileMeta {
 
 	// read file
 	data, err := ioutil.ReadFile(filepath)
 	if err != nil {
-		return UploadedFileMeta{}, err
+		panic(err)
 	}
 
 	// unmarshall data from json
 	var uploadedFileMeta UploadedFileMeta
 	err = json.Unmarshal(data, &uploadedFileMeta)
 	if err != nil {
-		return UploadedFileMeta{}, err
+		panic(err)
 	}
 
-	return uploadedFileMeta, nil
+	return uploadedFileMeta
 }
 
 // PopulateFilesProperty populates the "files" property of an Admin object, given a list of Data files.

--- a/main.go
+++ b/main.go
@@ -61,7 +61,7 @@ func (dataFile UploadedDataFile) DetectFileType() string {
 	metaFilepath := filepath.Join(dataFile.path, strings.Replace(dataFile.filename, ".bin", ".info", 1))
 	fileinfo, err := LoadMetadata(metaFilepath)
 	if err != nil {
-		log.Fatal(err)
+		panic(err)
 	}
 	return ExtractFileTypeFromMetadata(metaFilepath, fileinfo) // e.g. "Sigfaible_debits.csv"
 }

--- a/main.go
+++ b/main.go
@@ -71,6 +71,23 @@ func (dataFile UploadedDataFile) GetFilename() string {
 	return dataFile.filename
 }
 
+type UnsupportedFilesError struct {
+	unsupportedFiles []string
+}
+
+// ReadFilenames returns the name of files found at the provided path.
+func ReadFilenames(path string) ([]string, error) {
+	var files []string
+	fileInfo, err := ioutil.ReadDir(path)
+	if err != nil {
+		return files, err
+	}
+	for _, file := range fileInfo {
+		files = append(files, file.Name())
+	}
+	return files, nil
+}
+
 // AugmentDataFile returns a SimpleDataFile or UploadedDataFile (if metadata had to be loaded).
 func AugmentDataFile(file string, pathname string) DataFile {
 	if strings.HasSuffix(file, ".bin") {
@@ -100,19 +117,6 @@ func PurePrepareImport(augmentedFilenames []DataFile) (AdminObject, error) {
 		errMsg = "unsupported: " + strings.Join(unsupportedFiles, ", ")
 	}
 	return AdminObject{"files": filesProperty}, errors.New(errMsg)
-}
-
-// ReadFilenames returns the name of files found at the provided path.
-func ReadFilenames(path string) ([]string, error) {
-	var files []string
-	fileInfo, err := ioutil.ReadDir(path)
-	if err != nil {
-		return files, err
-	}
-	for _, file := range fileInfo {
-		files = append(files, file.Name())
-	}
-	return files, nil
 }
 
 // LoadMetadata returns the metadata of a .bin file, by reading the given .info file.

--- a/main_test.go
+++ b/main_test.go
@@ -74,7 +74,6 @@ func TestPrepareImport(t *testing.T) {
 			assert.Equal(t, expected, res)
 		})
 	}
-
 }
 
 func TestPurePrepareImport(t *testing.T) {
@@ -118,23 +117,27 @@ func TestPurePrepareImport(t *testing.T) {
 
 func TestPopulateFilesProperty(t *testing.T) {
 	t.Run("PopulateFilesProperty should contain effectif file in \"effectif\" property", func(t *testing.T) {
-		filesProperty := PopulateFilesProperty([]DataFile{SimpleDataFile{"Sigfaibles_effectif_siret.csv"}})
+		filesProperty, _ := PopulateFilesProperty([]DataFile{SimpleDataFile{"Sigfaibles_effectif_siret.csv"}})
 		assert.Equal(t, []string{"Sigfaibles_effectif_siret.csv"}, filesProperty["effectif"])
 	})
 
 	t.Run("PopulateFilesProperty should contain one debit file in \"debit\" property", func(t *testing.T) {
-		filesProperty := PopulateFilesProperty([]DataFile{SimpleDataFile{"Sigfaibles_debits.csv"}})
+		filesProperty, _ := PopulateFilesProperty([]DataFile{SimpleDataFile{"Sigfaibles_debits.csv"}})
 		assert.Equal(t, []string{"Sigfaibles_debits.csv"}, filesProperty["debit"])
 	})
 
 	t.Run("PopulateFilesProperty should contain both debits files in \"debit\" property", func(t *testing.T) {
-		filesProperty := PopulateFilesProperty([]DataFile{SimpleDataFile{"Sigfaibles_debits.csv"}, SimpleDataFile{"Sigfaibles_debits2.csv"}})
+		filesProperty, _ := PopulateFilesProperty([]DataFile{SimpleDataFile{"Sigfaibles_debits.csv"}, SimpleDataFile{"Sigfaibles_debits2.csv"}})
 		assert.Equal(t, []string{"Sigfaibles_debits.csv", "Sigfaibles_debits2.csv"}, filesProperty["debit"])
 	})
 
 	t.Run("Should not include unsupported files", func(t *testing.T) {
-		filesProperty := PopulateFilesProperty([]DataFile{SimpleDataFile{"coco.csv"}})
+		filesProperty, _ := PopulateFilesProperty([]DataFile{SimpleDataFile{"coco.csv"}})
 		assert.Equal(t, FilesProperty{}, filesProperty)
+	})
+	t.Run("Should report unsupported files", func(t *testing.T) {
+		_, unsupportedFiles := PopulateFilesProperty([]DataFile{SimpleDataFile{"coco.csv"}})
+		assert.Equal(t, []string{"coco.csv"}, unsupportedFiles)
 	})
 }
 

--- a/main_test.go
+++ b/main_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -77,9 +78,10 @@ func TestPrepareImport(t *testing.T) {
 
 	t.Run("should return list of unsupported files", func(t *testing.T) {
 		dir := createTempFiles(t, "unsupported-file.csv") // TODO: also test with alone.bin (without .info)
-		_, error := PrepareImport(dir)
-		if assert.Error(t, error) {
-			assert.Equal(t, "unsupported: unsupported-file.csv", error.Error()) // TODO: more robust error matching
+		_, err := PrepareImport(dir)
+		var e *UnsupportedFilesError
+		if assert.Error(t, err) && errors.As(err, &e) {
+			assert.Equal(t, []string{"unsupported-file.csv"}, e.UnsupportedFiles)
 		}
 	})
 }

--- a/main_test.go
+++ b/main_test.go
@@ -74,6 +74,14 @@ func TestPrepareImport(t *testing.T) {
 			assert.Equal(t, expected, res)
 		})
 	}
+
+	t.Run("should return list of unsupported files", func(t *testing.T) {
+		dir := createTempFiles(t, "unsupported-file.csv") // TODO: also test with alone.bin (without .info)
+		_, error := PrepareImport(dir)
+		if assert.Error(t, error) {
+			assert.Equal(t, "unsupported: unsupported-file.csv", error.Error()) // TODO: more robust error matching
+		}
+	})
 }
 
 func TestPurePrepareImport(t *testing.T) {

--- a/main_test.go
+++ b/main_test.go
@@ -145,7 +145,7 @@ func MakeMetadata(metadataFields MetadataProperty) UploadedFileMeta {
 	return UploadedFileMeta{MetaData: metadataFields}
 }
 
-func TestGetFileTypeFromMetadata(t *testing.T) {
+func TestExtractFileTypeFromMetadata(t *testing.T) {
 
 	t.Run("should return \"debit\" for bin file which original name included \"debits\"", func(t *testing.T) {
 		got := ExtractFileTypeFromMetadata("9a047825d8173684b69994428449302f.bin", MakeMetadata(MetadataProperty{
@@ -172,7 +172,7 @@ func TestGetFileTypeFromMetadata(t *testing.T) {
 	})
 }
 
-func TestGetFileType(t *testing.T) {
+func TestExtractFileTypeFromFilename(t *testing.T) {
 
 	// inspired by https://github.com/golang/go/wiki/TableDrivenTests
 	cases := []struct {

--- a/main_test.go
+++ b/main_test.go
@@ -88,7 +88,7 @@ func TestPurePrepareImport(t *testing.T) {
 	t.Run("Should return the filename in the debit property", func(t *testing.T) {
 		filename := SimpleDataFile{"Sigfaibles_debits.csv"}
 
-		res := PurePrepareImport([]DataFile{filename})
+		res, _ := PurePrepareImport([]DataFile{filename})
 		expected := AdminObject{
 			"files": FilesProperty{"debit": []string{"Sigfaibles_debits.csv"}},
 		}
@@ -96,7 +96,7 @@ func TestPurePrepareImport(t *testing.T) {
 	})
 
 	t.Run("Should return an empty json when there is no file", func(t *testing.T) {
-		res := PurePrepareImport([]DataFile{})
+		res, _ := PurePrepareImport([]DataFile{})
 		assert.Equal(t, AdminObject{"files": FilesProperty{}}, res)
 	})
 
@@ -113,7 +113,7 @@ func TestPurePrepareImport(t *testing.T) {
 		for _, file := range files {
 			augmentedFiles = append(augmentedFiles, SimpleDataFile{file})
 		}
-		res := PurePrepareImport(augmentedFiles)
+		res, _ := PurePrepareImport(augmentedFiles)
 		resFilesProperty := res["files"].(FilesProperty)
 		resultingFiles := []string{}
 		for _, filenames := range resFilesProperty {

--- a/main_test.go
+++ b/main_test.go
@@ -77,12 +77,19 @@ func TestPrepareImport(t *testing.T) {
 	}
 
 	t.Run("should return list of unsupported files", func(t *testing.T) {
-		dir := createTempFiles(t, "unsupported-file.csv") // TODO: also test with alone.bin (without .info)
+		dir := createTempFiles(t, "unsupported-file.csv")
 		_, err := PrepareImport(dir)
 		var e *UnsupportedFilesError
 		if assert.Error(t, err) && errors.As(err, &e) {
 			assert.Equal(t, []string{"unsupported-file.csv"}, e.UnsupportedFiles)
 		}
+	})
+
+	t.Run("should fail if missing .info file", func(t *testing.T) {
+		dir := createTempFiles(t, "lonely.bin")
+		assert.Panics(t, func() {
+			PrepareImport(dir)
+		})
 	})
 }
 

--- a/main_test.go
+++ b/main_test.go
@@ -47,6 +47,14 @@ func TestPrepareImport(t *testing.T) {
 		assert.Equal(t, expected, res)
 	})
 
+	cases := []struct {
+		id       string
+		filename string
+		goupPath string
+	}{
+		{"9a047825d8173684b69994428449302f", "Sigfaible_debits.csv", "urssaf"}
+	}
+
 	t.Run("Should support uploaded files (bin+info)", func(t *testing.T) {
 		dir := createTempFiles(t, "9a047825d8173684b69994428449302f.bin")
 

--- a/main_test.go
+++ b/main_test.go
@@ -51,41 +51,30 @@ func TestPrepareImport(t *testing.T) {
 		id       string
 		filename string
 		goupPath string
+		filetype string
 	}{
-		{"9a047825d8173684b69994428449302f", "Sigfaible_debits.csv", "urssaf"}
+		{"9a047825d8173684b69994428449302f", "Sigfaible_debits.csv", "urssaf", "debit"},
+		{"60d1bd320523904d8b8b427efbbd3928", "FICHIER_SF_2020_02.csv", "bdf", "bdf"},
 	}
 
-	t.Run("Should support uploaded files (bin+info)", func(t *testing.T) {
-		dir := createTempFiles(t, "9a047825d8173684b69994428449302f.bin")
+	for _, testCase := range cases {
+		t.Run("Uploaded file originally named "+testCase.filename+" should be of type "+testCase.filetype, func(t *testing.T) {
+			dir := createTempFiles(t, testCase.id+".bin")
 
-		tmpFilename := filepath.Join(dir, "9a047825d8173684b69994428449302f.info")
-		content := []byte("{\"MetaData\":{\"filename\":\"Sigfaible_debits.csv\",\"goup-path\":\"urssaf\"}}")
-		if err := ioutil.WriteFile(tmpFilename, content, 0666); err != nil {
-			t.Fatal(err.Error())
-		}
+			tmpFilename := filepath.Join(dir, testCase.id+".info")
+			content := []byte("{\"MetaData\":{\"filename\":\"" + testCase.filename + "\",\"goup-path\":\"" + testCase.goupPath + "\"}}")
+			if err := ioutil.WriteFile(tmpFilename, content, 0666); err != nil {
+				t.Fatal(err.Error())
+			}
 
-		res, _ := PrepareImport(dir)
-		expected := AdminObject{
-			"files": FilesProperty{"debit": []string{"9a047825d8173684b69994428449302f.bin"}},
-		}
-		assert.Equal(t, expected, res)
-	})
+			res, _ := PrepareImport(dir)
+			expected := AdminObject{
+				"files": FilesProperty{testCase.filetype: []string{testCase.id + ".bin"}},
+			}
+			assert.Equal(t, expected, res)
+		})
+	}
 
-	t.Run("Should use goup-path to detect file type", func(t *testing.T) {
-		dir := createTempFiles(t, "60d1bd320523904d8b8b427efbbd3928.bin")
-
-		tmpFilename := filepath.Join(dir, "60d1bd320523904d8b8b427efbbd3928.info")
-		content := []byte("{\"MetaData\":{\"filename\":\"FICHIER_SF_2020_02.csv\",\"goup-path\":\"bdf\"}}")
-		if err := ioutil.WriteFile(tmpFilename, content, 0666); err != nil {
-			t.Fatal(err.Error())
-		}
-
-		res, _ := PrepareImport(dir)
-		expected := AdminObject{
-			"files": FilesProperty{"bdf": []string{"60d1bd320523904d8b8b427efbbd3928.bin"}},
-		}
-		assert.Equal(t, expected, res)
-	})
 }
 
 func TestPurePrepareImport(t *testing.T) {


### PR DESCRIPTION
- PurePrepareImport retourne les noms de fichiers non supportés, quand c'est le cas (Note: à afficher depuis le script)
- LoadMetadata ne retourne plus d'erreurs, il panique
- Factorisation de TestPrepareImport
- Ajout de test en cas de fichier .bin sans metadata (.info)

## Ensuite

- la commande `prepare-import` devrait retourner la liste des fichiers non supportés, dans la sortie d'erreurs (stderr)
