### PR TITLE
fix: envoi de couverture de tests à DeepSource

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -40,3 +40,10 @@ jobs:
       run: |
         go get github.com/schrej/godacov
         go run github.com/schrej/godacov -t ${{ secrets.CODACY_REPOSITORY_TOKEN_FOR_COVERAGE }} -r ./coverage.out -c $GITHUB_SHA
+    
+    - name: Upload coverage to DeepSource
+      env:
+        DEEPSOURCE_DSN: ${{ secrets.DEEPSOURCE_DSN_FOR_COVERAGE }}
+      run: |
+        curl https://deepsource.io/cli | sh
+        ./bin/deepsource report --analyzer test-coverage --key go --value-file ./coverage.out

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -21,6 +21,10 @@ jobs:
 
     - name: Check out code into the Go module directory
       uses: actions/checkout@v2
+      with:
+        # for deepsource, cf https://deepsource.io/docs/how-to/add-go-cov-ci.html#with-github-actions
+        ref: ${{ github.event.pull_request.head.sha }}
+
 
     - name: Get dependencies
       run: |


### PR DESCRIPTION
References:
- https://deepsource.io/gh/signaux-faibles/prepare-import/settings/reporting
- https://deepsource.io/docs/analyzer/test-coverage.html#configuration-artifacts
- https://github.com/signaux-faibles/prepare-import/settings/secrets
- https://deepsource.io/docs/how-to/add-go-cov-ci.html#with-circle-ci