### PR TITLE
refactor: Correction de l'avertissement "unexported-return"

### DIFF
--- a/main.go
+++ b/main.go
@@ -146,22 +146,21 @@ func (b *batchKeyType) String() string {
 }
 
 // MarshalJSON will be called when serializing a BatchKey for MongoDB.
-func (key batchKeyType) MarshalJSON() ([]byte, error) {
-	return json.Marshal(key.value)
+func (b batchKeyType) MarshalJSON() ([]byte, error) {
+	return json.Marshal(b.value)
 }
 
 // UnmarshalJSON will parse a BatchKey from a MongoDB object.
-func (key *batchKeyType) UnmarshalJSON(data []byte) error {
-	if err := json.Unmarshal(data, &(key.value)); err != nil {
-		return err
-	}
-	return nil
+func (b *batchKeyType) UnmarshalJSON(data []byte) error {
+	return json.Unmarshal(data, &(b.value))
 }
 
+// BatchKey represents a valid batch key.
 type BatchKey interface {
 	String() string
 }
 
+// NewBatchKey constructs a valid batch key.
 func NewBatchKey(key string) (BatchKey, error) {
 	var isValidBatchKey = regexp.MustCompile(`^[0-9]{4}`)
 	if !isValidBatchKey.MatchString(key) {

--- a/main.go
+++ b/main.go
@@ -137,22 +137,10 @@ func PrepareImport(pathname string, batchKey BatchKey) (AdminObject, error) {
 	return PopulateAdminObject(augmentedFiles, batchKey)
 }
 
-type batchKeyType struct {
-	value string
-}
+type batchKeyType string
 
-func (b *batchKeyType) String() string {
-	return b.value
-}
-
-// MarshalJSON will be called when serializing a BatchKey for MongoDB.
-func (b batchKeyType) MarshalJSON() ([]byte, error) {
-	return json.Marshal(b.value)
-}
-
-// UnmarshalJSON will parse a BatchKey from a MongoDB object.
-func (b *batchKeyType) UnmarshalJSON(data []byte) error {
-	return json.Unmarshal(data, &(b.value))
+func (b batchKeyType) String() string {
+	return string(b)
 }
 
 // BatchKey represents a valid batch key.
@@ -164,9 +152,9 @@ type BatchKey interface {
 func NewBatchKey(key string) (BatchKey, error) {
 	var isValidBatchKey = regexp.MustCompile(`^[0-9]{4}`)
 	if !isValidBatchKey.MatchString(key) {
-		return &batchKeyType{""}, errors.New("la clé du batch doit respecter le format requis AAMM")
+		return batchKeyType(""), errors.New("la clé du batch doit respecter le format requis AAMM")
 	}
-	return &batchKeyType{key}, nil
+	return batchKeyType(key), nil
 }
 
 // PopulateAdminObject populates an AdminObject, given a list of data files.

--- a/main_test.go
+++ b/main_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"errors"
 	"io/ioutil"
+	"log"
 	"os"
 	"path/filepath"
 	"testing"
@@ -10,7 +11,15 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-const DUMMY_BATCHKEY batchKeyType = "1802"
+func newSafeBatchKey(key string) BatchKey {
+	batchKey, err := NewBatchKey(key)
+	if err != nil {
+		log.Fatal(err)
+	}
+	return batchKey
+}
+
+var DUMMY_BATCHKEY = newSafeBatchKey("1802")
 
 // Helper to create temporary files, and clean up after the execution of tests
 func createTempFiles(t *testing.T, filenames []string) string {
@@ -100,12 +109,12 @@ func TestPrepareImport(t *testing.T) {
 func TestBatchKey(t *testing.T) {
 
 	t.Run("Should accept valid batch key", func(t *testing.T) {
-		_, err := BatchKey("1802")
+		_, err := NewBatchKey("1802")
 		assert.NoError(t, err)
 	})
 
 	t.Run("Should fail if batch key is invalid", func(t *testing.T) {
-		_, err := BatchKey("")
+		_, err := NewBatchKey("")
 		assert.Error(t, err, "la clé du batch doit respecter le format requis AAMM")
 	})
 }
@@ -172,14 +181,14 @@ func TestPopulateAdminObject(t *testing.T) {
 	})
 
 	t.Run("Should return an _id property", func(t *testing.T) {
-		res, err := PopulateAdminObject([]DataFile{}, "1802")
+		res, err := PopulateAdminObject([]DataFile{}, newSafeBatchKey("1802"))
 		if assert.NoError(t, err) {
-			assert.Equal(t, IDProperty{"1802", "batch"}, res["_id"])
+			assert.Equal(t, IDProperty{newSafeBatchKey("1802"), "batch"}, res["_id"])
 		}
 	})
 
 	t.Run("Should return a date_fin consistent with batch key", func(t *testing.T) {
-		res, err := PopulateAdminObject([]DataFile{}, "1912") // ~= 12/2019
+		res, err := PopulateAdminObject([]DataFile{}, newSafeBatchKey("1912")) // ~= 12/2019
 		expected := map[string]string{"$date": "2019-12-01T00:00:00.000+0000"}
 		if assert.NoError(t, err) {
 			assert.Equal(t, expected, res["param"].(map[string]map[string]string)["date_fin"])


### PR DESCRIPTION
Cf https://github.com/signaux-faibles/prepare-import/pull/26#issuecomment-615194913.

Description de l'avertissement reporté par Codacy:

- exported `func BatchKey` returns unexported type `main.batchKeyType`, which can be annoying to use

```go
func BatchKey(key string) (batchKeyType, error) {
```