### PR TITLE
fix(#31): Les chemins d'accès de la propriété files doivent inclure le numéro de batch

### DIFF
--- a/end_to_end_golden.txt
+++ b/end_to_end_golden.txt
@@ -8,13 +8,13 @@
   ],
   "files": {
     "bdf": [
-      "abcdef.bin"
+      "/1802/abcdef.bin"
     ],
     "debit": [
-      "Sigfaibles_debits.csv"
+      "/1802/Sigfaibles_debits.csv"
     ],
     "effectif": [
-      "Sigfaibles_effectif_siret.csv"
+      "/1802/Sigfaibles_effectif_siret.csv"
     ]
   },
   "param": {

--- a/end_to_end_golden_err.txt
+++ b/end_to_end_golden_err.txt
@@ -1,4 +1,4 @@
-unsupported: unsupported.csv
+unsupported: /1802/unsupported.csv
 la clé du batch doit respecter le format requis AAMM
 
 Usage:

--- a/end_to_end_test.go
+++ b/end_to_end_test.go
@@ -32,7 +32,11 @@ var updateGoldenFile = flag.Bool("update", false, "Update the expected test valu
 func TestMain(t *testing.T) {
 	t.Run("prepare-import golden file", func(t *testing.T) {
 
-		dir := createTempFiles(t, []string{"Sigfaibles_effectif_siret.csv", "Sigfaibles_debits.csv", "abcdef.bin", "unsupported.csv"})
+		batch := "1802"
+
+		batchKey, _ := NewBatchKey(batch)
+
+		dir, parentDir := createTempFiles(t, batchKey, []string{"Sigfaibles_effectif_siret.csv", "Sigfaibles_debits.csv", "abcdef.bin", "unsupported.csv"})
 
 		content := []byte("{\"MetaData\":{\"filename\":\"FICHIER_SF_2020_02.csv\",\"goup-path\":\"bdf\"}}")
 		ioutil.WriteFile(filepath.Join(dir, "abcdef.info"), content, 0644)
@@ -40,11 +44,11 @@ func TestMain(t *testing.T) {
 		cmds := []*exec.Cmd{
 			exec.Command(
 				"./prepare-import",
-				"--path", dir,
-				"--batch", "1802",
+				"--path", parentDir,
+				"--batch", batch,
 				"--date-fin-effectif", "2014-01-01",
 			), // paramètres valides
-			exec.Command("./prepare-import", "--path", dir, "--batch", "180"), // nom de batch invalide
+			exec.Command("./prepare-import", "--path", parentDir, "--batch", "180"), // nom de batch invalide
 		}
 		var cmdOutput bytes.Buffer
 		var cmdError bytes.Buffer

--- a/end_to_end_test.go
+++ b/end_to_end_test.go
@@ -36,10 +36,10 @@ func TestMain(t *testing.T) {
 
 		batchKey, _ := NewBatchKey(batch)
 
-		dir, parentDir := createTempFiles(t, batchKey, []string{"Sigfaibles_effectif_siret.csv", "Sigfaibles_debits.csv", "abcdef.bin", "unsupported.csv"})
+		parentDir := createTempFiles(t, batchKey, []string{"Sigfaibles_effectif_siret.csv", "Sigfaibles_debits.csv", "abcdef.bin", "unsupported.csv"})
 
 		content := []byte("{\"MetaData\":{\"filename\":\"FICHIER_SF_2020_02.csv\",\"goup-path\":\"bdf\"}}")
-		ioutil.WriteFile(filepath.Join(dir, "abcdef.info"), content, 0644)
+		ioutil.WriteFile(filepath.Join(parentDir, batch, "abcdef.info"), content, 0644)
 
 		cmds := []*exec.Cmd{
 			exec.Command(

--- a/main.go
+++ b/main.go
@@ -62,9 +62,14 @@ func (b batchKeyType) String() string {
 	return string(b)
 }
 
+func (b batchKeyType) Path() string {
+	return "/" + string(b) + "/"
+}
+
 // BatchKey represents a valid batch key.
 type BatchKey interface {
 	String() string
+	Path() string
 }
 
 // NewBatchKey constructs a valid batch key.


### PR DESCRIPTION
Fixes #31.

## Changements apportés

- Les fichiers listés dans la propriété `files` résultante de l'appel à `prepare-import` sont préfixés par leur répertoire de batch. Ex: `/numero_batch/nom_fichier.csv`.
- Le paramètre `--path` attend le chemin du répertoire parent contenant un sous-répertoire par batch.

