### PR TITLE
fix(#32): Les fichiers *.bin n'ont plus d'extension

### DIFF
--- a/end_to_end_golden.txt
+++ b/end_to_end_golden.txt
@@ -8,7 +8,7 @@
   ],
   "files": {
     "bdf": [
-      "abcdef.bin"
+      "abcdef"
     ],
     "debit": [
       "Sigfaibles_debits.csv"

--- a/end_to_end_test.go
+++ b/end_to_end_test.go
@@ -32,7 +32,7 @@ var updateGoldenFile = flag.Bool("update", false, "Update the expected test valu
 func TestMain(t *testing.T) {
 	t.Run("prepare-import golden file", func(t *testing.T) {
 
-		dir := createTempFiles(t, []string{"Sigfaibles_effectif_siret.csv", "Sigfaibles_debits.csv", "abcdef.bin", "unsupported.csv"})
+		dir := createTempFiles(t, []string{"Sigfaibles_effectif_siret.csv", "Sigfaibles_debits.csv", "abcdef", "unsupported.csv"})
 
 		content := []byte("{\"MetaData\":{\"filename\":\"FICHIER_SF_2020_02.csv\",\"goup-path\":\"bdf\"}}")
 		ioutil.WriteFile(filepath.Join(dir, "abcdef.info"), content, 0644)

--- a/main.go
+++ b/main.go
@@ -146,7 +146,7 @@ type UploadedDataFile struct {
 
 // DetectFileType returns the type of that file (e.g. DEBIT).
 func (dataFile UploadedDataFile) DetectFileType() ValidFileType {
-	metaFilepath := filepath.Join(dataFile.path, strings.Replace(dataFile.filename, ".bin", ".info", 1))
+	metaFilepath := filepath.Join(dataFile.path, dataFile.filename+".info")
 	fileinfo := LoadMetadata(metaFilepath)
 	return ExtractFileTypeFromMetadata(metaFilepath, fileinfo) // e.g. "Sigfaible_debits.csv"
 }
@@ -180,7 +180,7 @@ func ReadFilenames(path string) ([]string, error) {
 
 // AugmentDataFile returns a SimpleDataFile or UploadedDataFile (if metadata had to be loaded).
 func AugmentDataFile(file string, pathname string) DataFile {
-	if strings.HasSuffix(file, ".bin") {
+	if !strings.Contains(file, ".") { // "bin" files have no extension => no dot in their filename
 		return UploadedDataFile{file, pathname}
 	}
 	return SimpleDataFile{file}
@@ -229,7 +229,7 @@ func PopulateAdminObject(augmentedFilenames []DataFile, batchKey BatchKey, dateF
 	}, err
 }
 
-// LoadMetadata returns the metadata of a .bin file, by reading the given .info file.
+// LoadMetadata returns the metadata of a bin file (without extension), by reading the given .info file.
 func LoadMetadata(filepath string) UploadedFileMeta {
 
 	// read file

--- a/main_test.go
+++ b/main_test.go
@@ -76,7 +76,7 @@ func TestPrepareImport(t *testing.T) {
 
 	for _, testCase := range cases {
 		t.Run("Uploaded file originally named "+testCase.filename+" should be of type "+string(testCase.filetype), func(t *testing.T) {
-			dir := createTempFiles(t, []string{testCase.id + ".bin"})
+			dir := createTempFiles(t, []string{testCase.id})
 
 			tmpFilename := filepath.Join(dir, testCase.id+".info")
 			content := []byte("{\"MetaData\":{\"filename\":\"" + testCase.filename + "\",\"goup-path\":\"" + testCase.goupPath + "\"}}")
@@ -85,7 +85,7 @@ func TestPrepareImport(t *testing.T) {
 			}
 
 			res, err := PrepareImport(dir, DUMMY_BATCHKEY, DUMMY_DATE_FIN_EFFECTIF)
-			expected := FilesProperty{testCase.filetype: []string{testCase.id + ".bin"}}
+			expected := FilesProperty{testCase.filetype: []string{testCase.id}}
 			if assert.NoError(t, err) {
 				assert.Equal(t, expected, res["files"])
 			}
@@ -102,7 +102,7 @@ func TestPrepareImport(t *testing.T) {
 	})
 
 	t.Run("should fail if missing .info file", func(t *testing.T) {
-		dir := createTempFiles(t, []string{"lonely.bin"})
+		dir := createTempFiles(t, []string{"lonely"})
 		assert.Panics(t, func() {
 			PrepareImport(dir, DUMMY_BATCHKEY, DUMMY_DATE_FIN_EFFECTIF)
 		})
@@ -239,7 +239,7 @@ func MakeMetadata(metadataFields MetadataProperty) UploadedFileMeta {
 func TestExtractFileTypeFromMetadata(t *testing.T) {
 
 	t.Run("should return \"debit\" for bin file which original name included \"debits\"", func(t *testing.T) {
-		got := ExtractFileTypeFromMetadata("9a047825d8173684b69994428449302f.bin", MakeMetadata(MetadataProperty{
+		got := ExtractFileTypeFromMetadata("9a047825d8173684b69994428449302f", MakeMetadata(MetadataProperty{
 			"filename":  "Sigfaible_debits.csv",
 			"goup-path": "urssaf",
 		}))
@@ -247,7 +247,7 @@ func TestExtractFileTypeFromMetadata(t *testing.T) {
 	})
 
 	t.Run("should return \"bdf\" for bin file which came from bdf", func(t *testing.T) {
-		got := ExtractFileTypeFromMetadata("60d1bd320523904d8b8b427efbbd3928.bin", MakeMetadata(MetadataProperty{
+		got := ExtractFileTypeFromMetadata("60d1bd320523904d8b8b427efbbd3928", MakeMetadata(MetadataProperty{
 			"filename":  "FICHIER_SF_2020_02.csv",
 			"goup-path": "bdf",
 		}))
@@ -255,7 +255,7 @@ func TestExtractFileTypeFromMetadata(t *testing.T) {
 	})
 
 	t.Run("should return \"interim\" for bin file which had a sas7dbat extension", func(t *testing.T) {
-		got := ExtractFileTypeFromMetadata("ab8613ab66ebddb2db21e36b92fc5b70.bin", MakeMetadata(MetadataProperty{
+		got := ExtractFileTypeFromMetadata("ab8613ab66ebddb2db21e36b92fc5b70", MakeMetadata(MetadataProperty{
 			"filename":  "tab_19m10.sas7bdat",
 			"goup-path": "dgefp",
 		}))

--- a/signauxfaiblesTypes.go
+++ b/signauxfaiblesTypes.go
@@ -51,7 +51,7 @@ type UploadedFileMeta struct {
 	MetaData MetadataProperty
 }
 
-// ExtractFileTypeFromMetadata returns the type of a .bin file, based on the contents of the associated .info file.
+// ExtractFileTypeFromMetadata returns the type of a bin file (without extension), based on the contents of the associated .info file.
 func ExtractFileTypeFromMetadata(filename string, fileinfo UploadedFileMeta) ValidFileType {
 	metadata := fileinfo.MetaData
 	if metadata["goup-path"] == "bdf" {


### PR DESCRIPTION
Fixes #32.

Désormais, les fichiers de données "bin" (associés à un fichier `.info`) n'ont plus d'extension.