### PR TITLE
fix(github): "PR has only one non-merge commit and it's not semantic"

### DIFF
--- a/.github/semantic.yml
+++ b/.github/semantic.yml
@@ -1,0 +1,2 @@
+# "Semantic Pull Request" to just check the PR title, and ignore the commits messages
+titleOnly: true


### PR DESCRIPTION
Pour éviter l'erreur "PR has only one non-merge commit and it's not semantic" quand on soumet une PR GitHub ne contenant qu'un sel commit dont le message n'est pas un "conventional commit". Observée dans PR #36, et celle-ci.

Sachant qu'on fusionne nos PRs en "squashant" ses commits, seul le titre de la PR a besoin d'être un "conventional commit", au final.

![image](https://user-images.githubusercontent.com/531781/93741349-89bdea80-fbec-11ea-8419-506f8a1b83bb.png)
