### PR TITLE
fix: Fin d'intégration de la détection de date_fin_effectif + refactoring

### DIFF
--- a/createfilter/UrssafToPeriod.go
+++ b/createfilter/UrssafToPeriod.go
@@ -63,10 +63,11 @@ func UrssafToPeriod(urssaf string) (Periode, error) {
 	return period, nil
 }
 
-func effectifColNameToPeriod(colName string) (periode Periode, err error) {
+func effectifColNameToDate(colName string) (time.Time, error) {
 	if colName[0:3] != "eff" {
-		return periode, errors.New("this column is not a valid period: " + colName)
+		return time.Time{}, errors.New("this column is not a valid period: " + colName)
 	}
 	urssafPeriode := colName[3:9]
-	return UrssafToPeriod(urssafPeriode)
+	periode, err := UrssafToPeriod(urssafPeriode)
+	return periode.Start, err
 }

--- a/createfilter/main.go
+++ b/createfilter/main.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"regexp"
 	"strconv"
+	"time"
 )
 
 // Usage: $ ./create_filter --path test_data.csv
@@ -118,21 +119,22 @@ func isInsidePerimeter(record []string, nbMois, minEffectif int) bool {
 	return false
 }
 
-func detectDateFinEffectif(path string, nIgnoredCols int) (period Periode, err error) {
+// DetectDateFinEffectif determines DateFinEffectif by parsing the effectif file.
+func DetectDateFinEffectif(path string, nIgnoredCols int) (dateFinEffectif time.Time, err error) {
 	f, err := os.Open(path)
 	defer f.Close()
 	if err != nil {
-		return period, err
+		return time.Time{}, err
 	}
 	r := initializeEffectifReader(f)
 	header, err := r.Read() // en tête
 	if err != nil {
-		return period, err
+		return time.Time{}, err
 	}
 	nbColsToExclude := guessLastNMissingFromReader(r, nIgnoredCols)
 	lastColWithValue := len(header) - 1 - nbColsToExclude - nIgnoredCols
 	lastPeriodWithValue := header[lastColWithValue]
-	return effectifColNameToPeriod(lastPeriodWithValue)
+	return effectifColNameToDate(lastPeriodWithValue)
 }
 
 func guessLastNMissing(path string, nIgnoredCols int) int {

--- a/createfilter/main_test.go
+++ b/createfilter/main_test.go
@@ -36,13 +36,10 @@ func TestCreateFilter(t *testing.T) {
 }
 
 func TestDetectDateFinEffectif(t *testing.T) {
-	expectedPeriod := Periode{
-		Start: time.Date(2020, time.Month(1), 1, 0, 0, 0, 0, time.UTC),
-		End:   time.Date(2020, time.Month(2), 1, 0, 0, 0, 0, time.UTC),
-	}
-	actualPeriod, err := detectDateFinEffectif("test_data.csv", DefaultNbIgnoredCols) // => col name: "eff202011"
+	expectedDate := time.Date(2020, time.Month(1), 1, 0, 0, 0, 0, time.UTC)
+	actualDate, err := DetectDateFinEffectif("test_data.csv", DefaultNbIgnoredCols) // => col name: "eff202011"
 	if assert.NoError(t, err) {
-		assert.Equal(t, expectedPeriod, actualPeriod)
+		assert.Equal(t, expectedDate, actualDate)
 	}
 }
 

--- a/prepareimport/adminobject.go
+++ b/prepareimport/adminobject.go
@@ -13,6 +13,13 @@ type IDProperty struct {
 	Type string   `json:"type"`
 }
 
+// ParamProperty represents the "param" property of an Admin object.
+type ParamProperty struct {
+	DateDebut       MongoDate `json:"date_debut"`
+	DateFin         MongoDate `json:"date_fin"`
+	DateFinEffectif MongoDate `json:"date_fin_effectif"`
+}
+
 // UnsupportedFilesError is an Error object that lists files that were not supported.
 type UnsupportedFilesError struct {
 	UnsupportedFiles []string

--- a/prepareimport/adminobject.go
+++ b/prepareimport/adminobject.go
@@ -13,19 +13,6 @@ type IDProperty struct {
 	Type string   `json:"type"`
 }
 
-// PopulateAdminObject populates an AdminObject, given a list of data files.
-func PopulateAdminObject(augmentedFilenames []DataFile, batchKey BatchKey, dateFinEffectif DateFinEffectif) (AdminObject /*UnsupportedFiles*/, []string) {
-
-	filesProperty, unsupportedFiles := PopulateFilesProperty(augmentedFilenames, batchKey.Path())
-	completeTypes := populateCompleteTypesProperty(filesProperty)
-
-	return AdminObject{
-		"_id":            IDProperty{batchKey, "batch"},
-		"files":          filesProperty,
-		"complete_types": completeTypes,
-	}, unsupportedFiles
-}
-
 // UnsupportedFilesError is an Error object that lists files that were not supported.
 type UnsupportedFilesError struct {
 	UnsupportedFiles []string

--- a/prepareimport/adminobject_test.go
+++ b/prepareimport/adminobject_test.go
@@ -33,37 +33,6 @@ func TestPopulateAdminObject(t *testing.T) {
 		assert.Equal(t, expected, res["complete_types"])
 	})
 
-	t.Run("Should return an empty json when there is no file", func(t *testing.T) {
-		res, unsupported := PopulateAdminObject([]DataFile{}, dummyBatchKey, validDateFinEffectif)
-		assert.Len(t, unsupported, 0)
-		assert.Equal(t, FilesProperty{}, res["files"])
-	})
-
-	t.Run("Should support multiple types of csv files", func(t *testing.T) {
-		files := []string{
-			"diane_req_2002.csv",              // --> DIANE
-			"diane_req_dom_2002.csv",          // --> DIANE
-			"effectif_dom.csv",                // --> EFFECTIF
-			"filter_siren_2002.csv",           // --> FILTER
-			"sireneUL.csv",                    // --> SIRENE_UL
-			"StockEtablissement_utf8_geo.csv", // --> SIRENE
-		}
-		expectedFiles := []string{}
-		augmentedFiles := []DataFile{}
-		for _, file := range files {
-			expectedFiles = append(expectedFiles, dummyBatchKey.Path()+file)
-			augmentedFiles = append(augmentedFiles, SimpleDataFile{file})
-		}
-		res, unsupported := PopulateAdminObject(augmentedFiles, dummyBatchKey, validDateFinEffectif)
-		assert.Len(t, unsupported, 0)
-		resFilesProperty := res["files"].(FilesProperty)
-		resultingFiles := []string{}
-		for _, filenames := range resFilesProperty {
-			resultingFiles = append(resultingFiles, filenames...)
-		}
-		assert.Subset(t, resultingFiles, expectedFiles)
-	})
-
 	t.Run("Should return an _id property", func(t *testing.T) {
 		res, unsupported := PopulateAdminObject([]DataFile{}, newSafeBatchKey("1802"), validDateFinEffectif)
 		assert.Len(t, unsupported, 0)

--- a/prepareimport/adminobject_test.go
+++ b/prepareimport/adminobject_test.go
@@ -21,15 +21,6 @@ func TestPopulateCompleteTypesProperty(t *testing.T) {
 
 }
 
-func TestPopulateAdminObject(t *testing.T) {
-
-	t.Run("Should return an _id property", func(t *testing.T) {
-		res, unsupported := PopulateAdminObject([]DataFile{}, newSafeBatchKey("1802"), validDateFinEffectif)
-		assert.Len(t, unsupported, 0)
-		assert.Equal(t, IDProperty{newSafeBatchKey("1802"), "batch"}, res["_id"])
-	})
-}
-
 func TestPopulateParamProperty(t *testing.T) {
 	t.Run("Should return a date_fin consistent with batch key", func(t *testing.T) {
 		res := populateParamProperty(newSafeBatchKey("1912"), validDateFinEffectif)

--- a/prepareimport/adminobject_test.go
+++ b/prepareimport/adminobject_test.go
@@ -6,32 +6,22 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestPopulateAdminObject(t *testing.T) {
-	t.Run("Should return the filename in the debit property", func(t *testing.T) {
-		filename := SimpleDataFile{"Sigfaibles_debits.csv"}
-
-		res, unsupported := PopulateAdminObject([]DataFile{filename}, dummyBatchKey, validDateFinEffectif)
-		expected := FilesProperty{debit: []string{dummyBatchKey.Path() + "Sigfaibles_debits.csv"}}
-		assert.Len(t, unsupported, 0)
-		assert.Equal(t, expected, res["files"])
-	})
-
-	t.Run("Should return an empty complete_types property", func(t *testing.T) {
-		filename := SimpleDataFile{"Sigfaibles_debits.csv"}
-
-		res, unsupported := PopulateAdminObject([]DataFile{filename}, dummyBatchKey, validDateFinEffectif)
+func TestPopulateCompleteTypesProperty(t *testing.T) {
+	t.Run("Should not return a debit file as a complete_type", func(t *testing.T) {
+		res := populateCompleteTypesProperty(FilesProperty{"debit": {"Sigfaibles_debits.csv"}})
 		expected := []ValidFileType{}
-		assert.Len(t, unsupported, 0)
-		assert.Equal(t, expected, res["complete_types"])
+		assert.Equal(t, expected, res)
 	})
 
 	t.Run("Should return apconso as a complete_type", func(t *testing.T) {
-		filename := SimpleDataFile{"act_partielle_conso_depuis2014_FRANCE.csv"}
-		res, unsupported := PopulateAdminObject([]DataFile{filename}, dummyBatchKey, validDateFinEffectif)
+		res := populateCompleteTypesProperty(FilesProperty{"apconso": {"act_partielle_conso_depuis2014_FRANCE.csv"}})
 		expected := []ValidFileType{apconso}
-		assert.Len(t, unsupported, 0)
-		assert.Equal(t, expected, res["complete_types"])
+		assert.Equal(t, expected, res)
 	})
+
+}
+
+func TestPopulateAdminObject(t *testing.T) {
 
 	t.Run("Should return an _id property", func(t *testing.T) {
 		res, unsupported := PopulateAdminObject([]DataFile{}, newSafeBatchKey("1802"), validDateFinEffectif)

--- a/prepareimport/filesproperty.go
+++ b/prepareimport/filesproperty.go
@@ -1,14 +1,27 @@
 package prepareimport
 
 import (
+	"path"
 	"strings"
 )
 
 // FilesProperty represents the "files" property of an Admin object.
 type FilesProperty map[ValidFileType][]string
 
-// PopulateFilesProperty populates the "files" property of an Admin object, given a list of Data files.
-func PopulateFilesProperty(filenames []DataFile, prefix string) (FilesProperty, []string) {
+// PopulateFilesProperty populates the "files" property of an Admin object, given a path.
+func PopulateFilesProperty(pathname string, batchKey BatchKey) (FilesProperty, []string) {
+	batchPath := path.Join(pathname, batchKey.String())
+	filenames, _ := ReadFilenames(batchPath)
+	augmentedFiles := []DataFile{}
+	for _, file := range filenames {
+		augmentedFiles = append(augmentedFiles, AugmentDataFile(file, batchPath))
+	}
+
+	return PopulateFilesPropertyFromDataFiles(augmentedFiles, batchKey.Path())
+}
+
+// PopulateFilesPropertyFromDataFiles populates the "files" property of an Admin object, given a list of Data files.
+func PopulateFilesPropertyFromDataFiles(filenames []DataFile, prefix string) (FilesProperty, []string) {
 	filesProperty := FilesProperty{}
 	unsupportedFiles := []string{}
 	for _, filename := range filenames {

--- a/prepareimport/filesproperty.go
+++ b/prepareimport/filesproperty.go
@@ -1,6 +1,7 @@
 package prepareimport
 
 import (
+	"io/ioutil"
 	"path"
 	"strings"
 )
@@ -41,9 +42,15 @@ func PopulateFilesPropertyFromDataFiles(filenames []DataFile, prefix string) (Fi
 	return filesProperty, unsupportedFiles
 }
 
-// ParamProperty represents the "param" property of an Admin object.
-type ParamProperty struct {
-	DateDebut       MongoDate `json:"date_debut"`
-	DateFin         MongoDate `json:"date_fin"`
-	DateFinEffectif MongoDate `json:"date_fin_effectif"`
+// ReadFilenames returns the name of files found at the provided path.
+func ReadFilenames(path string) ([]string, error) {
+	var files []string
+	fileInfo, err := ioutil.ReadDir(path)
+	if err != nil {
+		return files, err
+	}
+	for _, file := range fileInfo {
+		files = append(files, file.Name())
+	}
+	return files, nil
 }

--- a/prepareimport/filesproperty_test.go
+++ b/prepareimport/filesproperty_test.go
@@ -22,9 +22,9 @@ func TestPopulateFilesProperty(t *testing.T) {
 
 	t.Run("PopulateFilesProperty should contain one debit file in \"debit\" property", func(t *testing.T) {
 		filesProperty, unsupportedFiles := PopulateFilesProperty([]DataFile{SimpleDataFile{"Sigfaibles_debits.csv"}}, dummyBatchKey.Path())
-		if assert.Len(t, unsupportedFiles, 0) {
-			assert.Equal(t, []string{dummyBatchKey.Path() + "Sigfaibles_debits.csv"}, filesProperty[debit])
-		}
+		expected := FilesProperty{debit: []string{dummyBatchKey.Path() + "Sigfaibles_debits.csv"}}
+		assert.Len(t, unsupportedFiles, 0)
+		assert.Equal(t, expected, filesProperty)
 	})
 
 	t.Run("PopulateFilesProperty should contain both debits files in \"debit\" property", func(t *testing.T) {

--- a/prepareimport/filesproperty_test.go
+++ b/prepareimport/filesproperty_test.go
@@ -8,27 +8,27 @@ import (
 
 func TestPopulateFilesProperty(t *testing.T) {
 	t.Run("Should return an empty json when there is no file", func(t *testing.T) {
-		filesProperty, unsupportedFiles := PopulateFilesProperty([]DataFile{}, dummyBatchKey.Path())
+		filesProperty, unsupportedFiles := PopulateFilesPropertyFromDataFiles([]DataFile{}, dummyBatchKey.Path())
 		assert.Len(t, unsupportedFiles, 0)
 		assert.Equal(t, FilesProperty{}, filesProperty)
 	})
 
 	t.Run("PopulateFilesProperty should contain effectif file in \"effectif\" property", func(t *testing.T) {
-		filesProperty, unsupportedFiles := PopulateFilesProperty([]DataFile{SimpleDataFile{"Sigfaibles_effectif_siret.csv"}}, dummyBatchKey.Path())
+		filesProperty, unsupportedFiles := PopulateFilesPropertyFromDataFiles([]DataFile{SimpleDataFile{"Sigfaibles_effectif_siret.csv"}}, dummyBatchKey.Path())
 		if assert.Len(t, unsupportedFiles, 0) {
 			assert.Equal(t, []string{dummyBatchKey.Path() + "Sigfaibles_effectif_siret.csv"}, filesProperty[effectif])
 		}
 	})
 
 	t.Run("PopulateFilesProperty should contain one debit file in \"debit\" property", func(t *testing.T) {
-		filesProperty, unsupportedFiles := PopulateFilesProperty([]DataFile{SimpleDataFile{"Sigfaibles_debits.csv"}}, dummyBatchKey.Path())
+		filesProperty, unsupportedFiles := PopulateFilesPropertyFromDataFiles([]DataFile{SimpleDataFile{"Sigfaibles_debits.csv"}}, dummyBatchKey.Path())
 		expected := FilesProperty{debit: []string{dummyBatchKey.Path() + "Sigfaibles_debits.csv"}}
 		assert.Len(t, unsupportedFiles, 0)
 		assert.Equal(t, expected, filesProperty)
 	})
 
 	t.Run("PopulateFilesProperty should contain both debits files in \"debit\" property", func(t *testing.T) {
-		filesProperty, unsupportedFiles := PopulateFilesProperty([]DataFile{SimpleDataFile{"Sigfaibles_debits.csv"}, SimpleDataFile{"Sigfaibles_debits2.csv"}}, dummyBatchKey.Path())
+		filesProperty, unsupportedFiles := PopulateFilesPropertyFromDataFiles([]DataFile{SimpleDataFile{"Sigfaibles_debits.csv"}, SimpleDataFile{"Sigfaibles_debits2.csv"}}, dummyBatchKey.Path())
 		if assert.Len(t, unsupportedFiles, 0) {
 			assert.Equal(t, []string{dummyBatchKey.Path() + "Sigfaibles_debits.csv", dummyBatchKey.Path() + "Sigfaibles_debits2.csv"}, filesProperty[debit])
 		}
@@ -53,18 +53,18 @@ func TestPopulateFilesProperty(t *testing.T) {
 			expectedFiles[file.Type] = append(expectedFiles[file.Type], dummyBatchKey.Path()+file.Filename)
 			inputFiles = append(inputFiles, SimpleDataFile{file.Filename})
 		}
-		resFilesProperty, unsupportedFiles := PopulateFilesProperty(inputFiles, dummyBatchKey.Path())
+		resFilesProperty, unsupportedFiles := PopulateFilesPropertyFromDataFiles(inputFiles, dummyBatchKey.Path())
 		assert.Len(t, unsupportedFiles, 0)
 		assert.Equal(t, expectedFiles, resFilesProperty)
 	})
 
 	t.Run("Should not include unsupported files", func(t *testing.T) {
-		filesProperty, unsupportedFiles := PopulateFilesProperty([]DataFile{SimpleDataFile{"coco.csv"}}, dummyBatchKey.Path())
+		filesProperty, unsupportedFiles := PopulateFilesPropertyFromDataFiles([]DataFile{SimpleDataFile{"coco.csv"}}, dummyBatchKey.Path())
 		assert.Len(t, unsupportedFiles, 1)
 		assert.Equal(t, FilesProperty{}, filesProperty)
 	})
 	t.Run("Should report unsupported files", func(t *testing.T) {
-		_, unsupportedFiles := PopulateFilesProperty([]DataFile{SimpleDataFile{"coco.csv"}}, dummyBatchKey.Path())
+		_, unsupportedFiles := PopulateFilesPropertyFromDataFiles([]DataFile{SimpleDataFile{"coco.csv"}}, dummyBatchKey.Path())
 		assert.Equal(t, []string{dummyBatchKey.Path() + "coco.csv"}, unsupportedFiles)
 	})
 }

--- a/prepareimport/prepareimport.go
+++ b/prepareimport/prepareimport.go
@@ -2,6 +2,7 @@ package prepareimport
 
 import (
 	"errors"
+	"fmt"
 	"io/ioutil"
 	"os"
 	"path"
@@ -28,11 +29,13 @@ func PrepareImport(pathname string, batchKey BatchKey, providedDateFinEffectif s
 
 	var dateFinEffectif time.Time
 	if filesProperty["filter"] == nil && filesProperty["effectif"] != nil {
+		if len(filesProperty["effectif"]) != 1 {
+			return nil, fmt.Errorf("generating a filter requires just 1 effectif file, found: %s", filesProperty["effectif"])
+		}
 		err = createAndAppendFilter(filesProperty, batchKey, pathname)
 		if err != nil {
 			return nil, err
 		}
-		// TODO: make sure there is only one effectif file
 		effectifFile := path.Join(pathname, filesProperty["effectif"][0])
 		dateFinEffectif, err = createfilter.DetectDateFinEffectif(effectifFile, createfilter.DefaultNbIgnoredCols)
 		if err != nil {

--- a/prepareimport/prepareimport.go
+++ b/prepareimport/prepareimport.go
@@ -23,7 +23,6 @@ func PrepareImport(pathname string, batchKey BatchKey, providedDateFinEffectif s
 		augmentedFiles = append(augmentedFiles, AugmentDataFile(file, batchPath))
 	}
 
-	// adminObject, unsupportedFiles := PopulateAdminObject(augmentedFiles, batchKey, dateFinEffectif) // TODO: de-duplicate code
 	filesProperty, unsupportedFiles := PopulateFilesProperty(augmentedFiles, batchKey.Path())
 	completeTypes := populateCompleteTypesProperty(filesProperty)
 

--- a/prepareimport/prepareimport.go
+++ b/prepareimport/prepareimport.go
@@ -3,7 +3,6 @@ package prepareimport
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"time"
@@ -85,19 +84,6 @@ func createAndAppendFilter(filesProperty FilesProperty, batchKey BatchKey, pathn
 	}
 	filesProperty["filter"] = append(filesProperty["filter"], filterFileName)
 	return nil
-}
-
-// ReadFilenames returns the name of files found at the provided path.
-func ReadFilenames(path string) ([]string, error) {
-	var files []string
-	fileInfo, err := ioutil.ReadDir(path)
-	if err != nil {
-		return files, err
-	}
-	for _, file := range fileInfo {
-		files = append(files, file.Name())
-	}
-	return files, nil
 }
 
 func fileExists(filename string) bool {

--- a/prepareimport/prepareimport.go
+++ b/prepareimport/prepareimport.go
@@ -32,7 +32,12 @@ func PrepareImport(pathname string, batchKey BatchKey, providedDateFinEffectif s
 		if err != nil {
 			return nil, err
 		}
-		dateFinEffectif = time.Date(2020, time.Month(1), 1, 0, 0, 0, 0, time.UTC) // TODO: detect from file
+		// TODO: make sure there is only one effectif file
+		effectifFile := path.Join(pathname, filesProperty["effectif"][0])
+		dateFinEffectif, err = createfilter.DetectDateFinEffectif(effectifFile, createfilter.DefaultNbIgnoredCols)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	if filesProperty["filter"] == nil || len(filesProperty["filter"]) == 0 {

--- a/prepareimport/prepareimport.go
+++ b/prepareimport/prepareimport.go
@@ -13,18 +13,8 @@ import (
 
 // PrepareImport generates an Admin object from files found at given pathname of the file system.
 func PrepareImport(pathname string, batchKey BatchKey, providedDateFinEffectif string) (AdminObject, error) {
-
-	batchPath := path.Join(pathname, batchKey.String())
-	filenames, err := ReadFilenames(batchPath)
-	if err != nil {
-		return nil, err
-	}
-	augmentedFiles := []DataFile{}
-	for _, file := range filenames {
-		augmentedFiles = append(augmentedFiles, AugmentDataFile(file, batchPath))
-	}
-
-	filesProperty, unsupportedFiles := PopulateFilesProperty(augmentedFiles, batchKey.Path())
+	var err error
+	filesProperty, unsupportedFiles := PopulateFilesProperty(pathname, batchKey)
 	completeTypes := populateCompleteTypesProperty(filesProperty)
 
 	var dateFinEffectif time.Time

--- a/prepareimport/prepareimport_test.go
+++ b/prepareimport/prepareimport_test.go
@@ -46,6 +46,15 @@ func TestPrepareImport(t *testing.T) {
 		}
 	})
 
+	t.Run("Should return an _id property", func(t *testing.T) {
+		batch := newSafeBatchKey("1802")
+		dir := CreateTempFiles(t, batch, []string{"filter_2002.csv"})
+		res, err := PrepareImport(dir, batch, dummyDateFinEffectif)
+		if assert.NoError(t, err) {
+			assert.Equal(t, IDProperty{batch, "batch"}, res["_id"])
+		}
+	})
+
 	cases := []struct {
 		id       string
 		filename string

--- a/prepareimport/prepareimport_test.go
+++ b/prepareimport/prepareimport_test.go
@@ -30,6 +30,13 @@ func TestPrepareImport(t *testing.T) {
 		assert.Equal(t, expected, err.Error())
 	})
 
+	t.Run("Should warn if 2 effectif files are provided", func(t *testing.T) {
+		dir := CreateTempFiles(t, dummyBatchKey, []string{"Sigfaible_effectif_siret.csv", "Sigfaible_effectif_siret2.csv"})
+		_, err := PrepareImport(dir, dummyBatchKey, dummyDateFinEffectif)
+		expected := "generating a filter requires just 1 effectif file, found: [/1802/Sigfaible_effectif_siret.csv /1802/Sigfaible_effectif_siret2.csv]"
+		assert.Equal(t, expected, err.Error())
+	})
+
 	t.Run("Should warn if neither effectif and date_fin_effectif are provided", func(t *testing.T) {
 		dir := CreateTempFiles(t, dummyBatchKey, []string{"filter_2002.csv"})
 		_, err := PrepareImport(dir, dummyBatchKey, "")

--- a/tools/procedure_import.md
+++ b/tools/procedure_import.md
@@ -69,13 +69,10 @@ _Entreprises mises à jour_ > _Données financières et descriptives_
 Utiliser `prepare-import` depuis `ssh stockage`:
 
 ```sh
-~/prepare-import/prepare-import -batch "<BATCH>" -date-fin-effectif "<DATE>" -path "../goup/public"
+~/prepare-import/prepare-import -batch "<BATCH>" -path "../goup/public"
 ```
 
-- Il faut également aller consulter à la main la dernière colonne non vide du
-  fichier effectif et renseigner sa valeur dans le fichier admin. (TODO)
-
-- Et enfin changer le nom du batch en langage naturel: ex "Février 2020".
+Penser à changer le nom du batch en langage naturel: ex "Février 2020".
 
 ## (Re)lancer le serveur API `dbmongo` (optionnel)
 


### PR DESCRIPTION
Suite de PR #42.

## Apports

- [x] appel à `DetectDateFinEffectif()` depuis `PrepareImport()`
- [x] supprimer `PopulateAdminObject()` <= finir de dispatcher les tests de `PopulateAdminObject()`
- [x] traiter les TODOs ajoutés dans PR #42
- [x] extraire une fonction pour alléger les responsabilités de `PrepareImport()`

## À faire dans une prochaine PR

- réfléchir à comment ne plus avoir à spécifier `date_fin_effectif` lors de la création de sous-batch, cf https://github.com/signaux-faibles/prepare-import/pull/42#discussion_r520745704