### PR TITLE
feat: Réutiliser les fichiers effectifs et filtre dans les sous-batches

### DIFF
--- a/end_to_end_golden_err.txt
+++ b/end_to_end_golden_err.txt
@@ -9,4 +9,4 @@ Usage:
     	Date de fin des données "effectif" fournies, au format AAAA-MM-JJ (année + mois + jour)
     	Exemple: 2014-01-01
   -path string
-    	Chemin d'accès aux fichiers données (default ".")
+    	Chemin d'accès au répertoire des batches (default ".")

--- a/main.go
+++ b/main.go
@@ -12,7 +12,7 @@ import (
 
 // Implementation of the prepare-import command.
 func main() {
-	var path = flag.String("path", ".", "Chemin d'accès aux fichiers données")
+	var path = flag.String("path", ".", "Chemin d'accès au répertoire des batches")
 	var batchKey = flag.String(
 		"batch",
 		"",

--- a/prepareimport/adminobject_test.go
+++ b/prepareimport/adminobject_test.go
@@ -6,15 +6,19 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func dummyBatchFile(filename string) BatchFile {
+	return newBatchFile(dummyBatchKey, filename)
+}
+
 func TestPopulateCompleteTypesProperty(t *testing.T) {
 	t.Run("Should not return a debit file as a complete_type", func(t *testing.T) {
-		res := populateCompleteTypesProperty(FilesProperty{"debit": {"Sigfaibles_debits.csv"}})
+		res := populateCompleteTypesProperty(FilesProperty{"debit": {dummyBatchFile("Sigfaibles_debits.csv")}})
 		expected := []ValidFileType{}
 		assert.Equal(t, expected, res)
 	})
 
 	t.Run("Should return apconso as a complete_type", func(t *testing.T) {
-		res := populateCompleteTypesProperty(FilesProperty{"apconso": {"act_partielle_conso_depuis2014_FRANCE.csv"}})
+		res := populateCompleteTypesProperty(FilesProperty{"apconso": {dummyBatchFile("act_partielle_conso_depuis2014_FRANCE.csv")}})
 		expected := []ValidFileType{apconso}
 		assert.Equal(t, expected, res)
 	})

--- a/prepareimport/batchkey.go
+++ b/prepareimport/batchkey.go
@@ -9,16 +9,20 @@ import (
 type BatchKey interface {
 	String() string
 	Path() string
+	IsSubBatch() bool
+	GetParentBatch() string
 }
 
 // NewBatchKey constructs a valid batch key.
 func NewBatchKey(key string) (BatchKey, error) {
-	var isValidBatchKey = regexp.MustCompile(`^[0-9]{4}`)
-	if !isValidBatchKey.MatchString(key) {
+	if !validBatchKey.MatchString(key) {
 		return batchKeyType(""), errors.New("la clé du batch doit respecter le format requis AAMM")
 	}
 	return batchKeyType(key), nil
 }
+
+var validBatchKey = regexp.MustCompile(`^[0-9]{4}`)
+var validSubBatchKey = regexp.MustCompile(`^([0-9]{4})_([0-9]{2})$`)
 
 type batchKeyType string
 
@@ -28,4 +32,13 @@ func (b batchKeyType) String() string {
 
 func (b batchKeyType) Path() string {
 	return "/" + string(b) + "/"
+}
+
+func (b batchKeyType) IsSubBatch() bool {
+	return validSubBatchKey.MatchString(string(b))
+}
+
+func (b batchKeyType) GetParentBatch() string {
+	matches := validSubBatchKey.FindStringSubmatch(string(b))
+	return matches[1]
 }

--- a/prepareimport/batchkey.go
+++ b/prepareimport/batchkey.go
@@ -11,7 +11,6 @@ type BatchKey interface {
 	Path() string
 	IsSubBatch() bool
 	GetParentBatch() string
-	GetParentPath() string
 }
 
 // NewBatchKey constructs a valid batch key.
@@ -44,8 +43,4 @@ func (b batchKeyType) GetParentBatch() string {
 		return validSubBatchKey.FindStringSubmatch(string(b))[1]
 	}
 	return b.String()
-}
-
-func (b batchKeyType) GetParentPath() string {
-	return "/" + b.GetParentBatch() + "/"
 }

--- a/prepareimport/batchkey.go
+++ b/prepareimport/batchkey.go
@@ -11,6 +11,7 @@ type BatchKey interface {
 	Path() string
 	IsSubBatch() bool
 	GetParentBatch() string
+	GetParentPath() string
 }
 
 // NewBatchKey constructs a valid batch key.
@@ -39,6 +40,12 @@ func (b batchKeyType) IsSubBatch() bool {
 }
 
 func (b batchKeyType) GetParentBatch() string {
-	matches := validSubBatchKey.FindStringSubmatch(string(b))
-	return matches[1]
+	if b.IsSubBatch() {
+		return validSubBatchKey.FindStringSubmatch(string(b))[1]
+	}
+	return b.String()
+}
+
+func (b batchKeyType) GetParentPath() string {
+	return "/" + b.GetParentBatch() + "/"
 }

--- a/prepareimport/batchkey_test.go
+++ b/prepareimport/batchkey_test.go
@@ -17,4 +17,19 @@ func TestBatchKey(t *testing.T) {
 		_, err := NewBatchKey("")
 		assert.EqualError(t, err, "la clé du batch doit respecter le format requis AAMM")
 	})
+
+	t.Run("Should return the path of a batch", func(t *testing.T) {
+		batchKey, _ := NewBatchKey("1802")
+		assert.Equal(t, "/1802/", batchKey.Path())
+	})
+
+	t.Run("Should return the parent of a sub-batch", func(t *testing.T) {
+		batchKey, _ := NewBatchKey("1802_01")
+		assert.Equal(t, "1802", batchKey.GetParentBatch())
+	})
+
+	t.Run("Should return the path of the parent of a sub-batch", func(t *testing.T) {
+		batchKey, _ := NewBatchKey("1802_01")
+		assert.Equal(t, "/1802/", batchKey.GetParentPath())
+	})
 }

--- a/prepareimport/batchkey_test.go
+++ b/prepareimport/batchkey_test.go
@@ -27,9 +27,4 @@ func TestBatchKey(t *testing.T) {
 		batchKey, _ := NewBatchKey("1802_01")
 		assert.Equal(t, "1802", batchKey.GetParentBatch())
 	})
-
-	t.Run("Should return the path of the parent of a sub-batch", func(t *testing.T) {
-		batchKey, _ := NewBatchKey("1802_01")
-		assert.Equal(t, "/1802/", batchKey.GetParentPath())
-	})
 }

--- a/prepareimport/filesproperty.go
+++ b/prepareimport/filesproperty.go
@@ -11,9 +11,8 @@ import (
 // BatchFile represents a file that is listed in a FilesProperty entry.
 type BatchFile interface {
 	BatchKey() BatchKey
-	FileName() string              // TODO: rename --> Name()
-	FilePath() string              // TODO: rename --> Path()
-	FilePathInParentBatch() string // TODO: rename --> PathInParentBatch()
+	FileName() string // TODO: rename --> Name()
+	FilePath() string // TODO: rename --> Path()
 }
 
 // FilesProperty represents the "files" property of an Admin object.
@@ -105,10 +104,6 @@ func (file batchFile) FileName() string {
 
 func (file batchFile) FilePath() string {
 	return file.batchKey.Path() + file.filename
-}
-
-func (file batchFile) FilePathInParentBatch() string {
-	return file.batchKey.GetParentPath() + file.filename
 }
 
 // MarshalJSON will be called when serializing the AdminObject.

--- a/prepareimport/filesproperty.go
+++ b/prepareimport/filesproperty.go
@@ -8,32 +8,6 @@ import (
 	"strings"
 )
 
-// BatchFile represents a file that is listed in a FilesProperty entry.
-type BatchFile interface {
-	BatchKey() BatchKey
-	Name() string
-	Path() string
-}
-
-// FilesProperty represents the "files" property of an Admin object.
-type FilesProperty map[ValidFileType][]BatchFile
-
-// GetFilterFile returns the filter file.
-func (fp FilesProperty) GetFilterFile() (BatchFile, error) {
-	if fp["filter"] == nil || len(fp["filter"]) != 1 {
-		return nil, fmt.Errorf("batch requires just 1 filter file, found: %s", fp["filter"])
-	}
-	return fp["filter"][0], nil
-}
-
-// GetEffectifFile returns the effectif file.
-func (fp FilesProperty) GetEffectifFile() (BatchFile, error) {
-	if fp["effectif"] == nil || len(fp["effectif"]) != 1 {
-		return nil, fmt.Errorf("batch requires just 1 effectif file, found: %s", fp["effectif"])
-	}
-	return fp["effectif"][0], nil
-}
-
 // PopulateFilesProperty populates the "files" property of an Admin object, given a path.
 func PopulateFilesProperty(pathname string, batchKey BatchKey) (FilesProperty, []string) {
 	batchPath := path.Join(pathname, batchKey.String())
@@ -42,7 +16,6 @@ func PopulateFilesProperty(pathname string, batchKey BatchKey) (FilesProperty, [
 	for _, file := range filenames {
 		augmentedFiles = append(augmentedFiles, AugmentDataFile(file, batchPath))
 	}
-
 	return PopulateFilesPropertyFromDataFiles(augmentedFiles, batchKey)
 }
 
@@ -52,7 +25,6 @@ func PopulateFilesPropertyFromDataFiles(filenames []DataFile, batchKey BatchKey)
 	unsupportedFiles := []string{}
 	for _, filename := range filenames {
 		filetype := filename.DetectFileType()
-
 		if filetype == "" {
 			if !strings.HasSuffix(filename.GetFilename(), ".info") {
 				unsupportedFiles = append(unsupportedFiles, batchKey.Path()+filename.GetFilename())
@@ -80,6 +52,32 @@ func ReadFilenames(path string) ([]string, error) {
 		}
 	}
 	return files, nil
+}
+
+// FilesProperty represents the "files" property of an Admin object.
+type FilesProperty map[ValidFileType][]BatchFile
+
+// GetFilterFile returns the filter file.
+func (fp FilesProperty) GetFilterFile() (BatchFile, error) {
+	if fp["filter"] == nil || len(fp["filter"]) != 1 {
+		return nil, fmt.Errorf("batch requires just 1 filter file, found: %s", fp["filter"])
+	}
+	return fp["filter"][0], nil
+}
+
+// GetEffectifFile returns the effectif file.
+func (fp FilesProperty) GetEffectifFile() (BatchFile, error) {
+	if fp["effectif"] == nil || len(fp["effectif"]) != 1 {
+		return nil, fmt.Errorf("batch requires just 1 effectif file, found: %s", fp["effectif"])
+	}
+	return fp["effectif"][0], nil
+}
+
+// BatchFile represents a file that is listed in a FilesProperty entry.
+type BatchFile interface {
+	BatchKey() BatchKey
+	Name() string
+	Path() string
 }
 
 func newBatchFile(batchKey BatchKey, filename string) BatchFile {

--- a/prepareimport/filesproperty.go
+++ b/prepareimport/filesproperty.go
@@ -72,7 +72,9 @@ func ReadFilenames(path string) ([]string, error) {
 		return files, err
 	}
 	for _, file := range fileInfo {
-		files = append(files, file.Name())
+		if !file.IsDir() {
+			files = append(files, file.Name())
+		}
 	}
 	return files, nil
 }

--- a/prepareimport/filesproperty.go
+++ b/prepareimport/filesproperty.go
@@ -18,11 +18,6 @@ type BatchFile interface {
 // FilesProperty represents the "files" property of an Admin object.
 type FilesProperty map[ValidFileType][]BatchFile
 
-// HasFilterFile returns true if a filter file is specified.
-func (fp FilesProperty) HasFilterFile() bool {
-	return fp["filter"] != nil && len(fp["filter"]) > 0
-}
-
 // GetFilterFile returns the filter file.
 func (fp FilesProperty) GetFilterFile() (BatchFile, error) {
 	if fp["filter"] == nil || len(fp["filter"]) != 1 {

--- a/prepareimport/filesproperty.go
+++ b/prepareimport/filesproperty.go
@@ -23,6 +23,14 @@ func (fp FilesProperty) HasFilterFile() bool {
 	return fp["filter"] != nil && len(fp["filter"]) > 0
 }
 
+// GetFilterFile returns the filter file.
+func (fp FilesProperty) GetFilterFile() (BatchFile, error) {
+	if fp["filter"] == nil || len(fp["filter"]) != 1 {
+		return nil, fmt.Errorf("batch requires just 1 filter file, found: %s", fp["filter"])
+	}
+	return fp["filter"][0], nil
+}
+
 // GetEffectifFile returns the effectif file.
 func (fp FilesProperty) GetEffectifFile() (BatchFile, error) {
 	if fp["effectif"] == nil || len(fp["effectif"]) != 1 {

--- a/prepareimport/filesproperty.go
+++ b/prepareimport/filesproperty.go
@@ -1,6 +1,7 @@
 package prepareimport
 
 import (
+	"fmt"
 	"io/ioutil"
 	"path"
 	"strings"
@@ -14,9 +15,12 @@ func (fp FilesProperty) HasFilterFile() bool {
 	return fp["filter"] != nil && len(fp["filter"]) > 0
 }
 
-// HasEffectifFile returns true if an effectif file is specified.
-func (fp FilesProperty) HasEffectifFile() bool {
-	return fp["effectif"] != nil && len(fp["effectif"]) > 0
+// GetEffectifFile returns the effectif file.
+func (fp FilesProperty) GetEffectifFile() (string, error) {
+	if fp["effectif"] == nil || len(fp["effectif"]) != 1 {
+		return "", fmt.Errorf("batch requires just 1 effectif file, found: %s", fp["effectif"])
+	}
+	return fp["effectif"][0], nil
 }
 
 // PopulateFilesProperty populates the "files" property of an Admin object, given a path.

--- a/prepareimport/filesproperty.go
+++ b/prepareimport/filesproperty.go
@@ -11,8 +11,8 @@ import (
 // BatchFile represents a file that is listed in a FilesProperty entry.
 type BatchFile interface {
 	BatchKey() BatchKey
-	FileName() string // TODO: rename --> Name()
-	FilePath() string // TODO: rename --> Path()
+	Name() string
+	Path() string
 }
 
 // FilesProperty represents the "files" property of an Admin object.
@@ -98,15 +98,15 @@ func (file batchFile) BatchKey() BatchKey {
 	return file.batchKey
 }
 
-func (file batchFile) FileName() string {
+func (file batchFile) Name() string {
 	return file.filename
 }
 
-func (file batchFile) FilePath() string {
+func (file batchFile) Path() string {
 	return file.batchKey.Path() + file.filename
 }
 
 // MarshalJSON will be called when serializing the AdminObject.
 func (file batchFile) MarshalJSON() ([]byte, error) {
-	return json.Marshal(file.FilePath())
+	return json.Marshal(file.Path())
 }

--- a/prepareimport/filesproperty.go
+++ b/prepareimport/filesproperty.go
@@ -9,6 +9,11 @@ import (
 // FilesProperty represents the "files" property of an Admin object.
 type FilesProperty map[ValidFileType][]string
 
+// HasFilterFile returns true if a filter file is specified.
+func (fp FilesProperty) HasFilterFile() bool {
+	return fp["filter"] != nil && len(fp["filter"]) > 0
+}
+
 // PopulateFilesProperty populates the "files" property of an Admin object, given a path.
 func PopulateFilesProperty(pathname string, batchKey BatchKey) (FilesProperty, []string) {
 	batchPath := path.Join(pathname, batchKey.String())

--- a/prepareimport/filesproperty.go
+++ b/prepareimport/filesproperty.go
@@ -14,6 +14,11 @@ func (fp FilesProperty) HasFilterFile() bool {
 	return fp["filter"] != nil && len(fp["filter"]) > 0
 }
 
+// HasEffectifFile returns true if an effectif file is specified.
+func (fp FilesProperty) HasEffectifFile() bool {
+	return fp["effectif"] != nil && len(fp["effectif"]) > 0
+}
+
 // PopulateFilesProperty populates the "files" property of an Admin object, given a path.
 func PopulateFilesProperty(pathname string, batchKey BatchKey) (FilesProperty, []string) {
 	batchPath := path.Join(pathname, batchKey.String())

--- a/prepareimport/filesproperty.go
+++ b/prepareimport/filesproperty.go
@@ -10,9 +10,10 @@ import (
 
 // BatchFile represents a file that is listed in a FilesProperty entry.
 type BatchFile interface {
-	FileName() string
-	FilePath() string
-	FilePathInParentBatch() string
+	BatchKey() BatchKey
+	FileName() string              // TODO: rename --> Name()
+	FilePath() string              // TODO: rename --> Path()
+	FilePathInParentBatch() string // TODO: rename --> PathInParentBatch()
 }
 
 // FilesProperty represents the "files" property of an Admin object.
@@ -84,26 +85,30 @@ func ReadFilenames(path string) ([]string, error) {
 
 func newBatchFile(batchKey BatchKey, filename string) BatchFile {
 	return batchFile{
-		BatchKey: batchKey,
-		Filename: filename,
+		batchKey: batchKey,
+		filename: filename,
 	}
 }
 
 type batchFile struct {
-	BatchKey BatchKey
-	Filename string
+	batchKey BatchKey
+	filename string
+}
+
+func (file batchFile) BatchKey() BatchKey {
+	return file.batchKey
 }
 
 func (file batchFile) FileName() string {
-	return file.Filename
+	return file.filename
 }
 
 func (file batchFile) FilePath() string {
-	return file.BatchKey.Path() + file.Filename
+	return file.batchKey.Path() + file.filename
 }
 
 func (file batchFile) FilePathInParentBatch() string {
-	return file.BatchKey.GetParentPath() + file.Filename
+	return file.batchKey.GetParentPath() + file.filename
 }
 
 // MarshalJSON will be called when serializing the AdminObject.

--- a/prepareimport/filesproperty_test.go
+++ b/prepareimport/filesproperty_test.go
@@ -8,29 +8,29 @@ import (
 
 func TestPopulateFilesProperty(t *testing.T) {
 	t.Run("Should return an empty json when there is no file", func(t *testing.T) {
-		filesProperty, unsupportedFiles := PopulateFilesPropertyFromDataFiles([]DataFile{}, dummyBatchKey.Path())
+		filesProperty, unsupportedFiles := PopulateFilesPropertyFromDataFiles([]DataFile{}, dummyBatchKey)
 		assert.Len(t, unsupportedFiles, 0)
 		assert.Equal(t, FilesProperty{}, filesProperty)
 	})
 
 	t.Run("PopulateFilesProperty should contain effectif file in \"effectif\" property", func(t *testing.T) {
-		filesProperty, unsupportedFiles := PopulateFilesPropertyFromDataFiles([]DataFile{SimpleDataFile{"Sigfaibles_effectif_siret.csv"}}, dummyBatchKey.Path())
+		filesProperty, unsupportedFiles := PopulateFilesPropertyFromDataFiles([]DataFile{SimpleDataFile{"Sigfaibles_effectif_siret.csv"}}, dummyBatchKey)
 		if assert.Len(t, unsupportedFiles, 0) {
-			assert.Equal(t, []string{dummyBatchKey.Path() + "Sigfaibles_effectif_siret.csv"}, filesProperty[effectif])
+			assert.Equal(t, []BatchFile{dummyBatchFile("Sigfaibles_effectif_siret.csv")}, filesProperty[effectif])
 		}
 	})
 
 	t.Run("PopulateFilesProperty should contain one debit file in \"debit\" property", func(t *testing.T) {
-		filesProperty, unsupportedFiles := PopulateFilesPropertyFromDataFiles([]DataFile{SimpleDataFile{"Sigfaibles_debits.csv"}}, dummyBatchKey.Path())
-		expected := FilesProperty{debit: []string{dummyBatchKey.Path() + "Sigfaibles_debits.csv"}}
+		filesProperty, unsupportedFiles := PopulateFilesPropertyFromDataFiles([]DataFile{SimpleDataFile{"Sigfaibles_debits.csv"}}, dummyBatchKey)
+		expected := FilesProperty{debit: {dummyBatchFile("Sigfaibles_debits.csv")}}
 		assert.Len(t, unsupportedFiles, 0)
 		assert.Equal(t, expected, filesProperty)
 	})
 
 	t.Run("PopulateFilesProperty should contain both debits files in \"debit\" property", func(t *testing.T) {
-		filesProperty, unsupportedFiles := PopulateFilesPropertyFromDataFiles([]DataFile{SimpleDataFile{"Sigfaibles_debits.csv"}, SimpleDataFile{"Sigfaibles_debits2.csv"}}, dummyBatchKey.Path())
+		filesProperty, unsupportedFiles := PopulateFilesPropertyFromDataFiles([]DataFile{SimpleDataFile{"Sigfaibles_debits.csv"}, SimpleDataFile{"Sigfaibles_debits2.csv"}}, dummyBatchKey)
 		if assert.Len(t, unsupportedFiles, 0) {
-			assert.Equal(t, []string{dummyBatchKey.Path() + "Sigfaibles_debits.csv", dummyBatchKey.Path() + "Sigfaibles_debits2.csv"}, filesProperty[debit])
+			assert.Equal(t, []BatchFile{dummyBatchFile("Sigfaibles_debits.csv"), dummyBatchFile("Sigfaibles_debits2.csv")}, filesProperty[debit])
 		}
 	})
 
@@ -50,21 +50,21 @@ func TestPopulateFilesProperty(t *testing.T) {
 		expectedFiles := FilesProperty{}
 		inputFiles := []DataFile{}
 		for _, file := range files {
-			expectedFiles[file.Type] = append(expectedFiles[file.Type], dummyBatchKey.Path()+file.Filename)
+			expectedFiles[file.Type] = append(expectedFiles[file.Type], dummyBatchFile(file.Filename))
 			inputFiles = append(inputFiles, SimpleDataFile{file.Filename})
 		}
-		resFilesProperty, unsupportedFiles := PopulateFilesPropertyFromDataFiles(inputFiles, dummyBatchKey.Path())
+		resFilesProperty, unsupportedFiles := PopulateFilesPropertyFromDataFiles(inputFiles, dummyBatchKey)
 		assert.Len(t, unsupportedFiles, 0)
 		assert.Equal(t, expectedFiles, resFilesProperty)
 	})
 
 	t.Run("Should not include unsupported files", func(t *testing.T) {
-		filesProperty, unsupportedFiles := PopulateFilesPropertyFromDataFiles([]DataFile{SimpleDataFile{"coco.csv"}}, dummyBatchKey.Path())
+		filesProperty, unsupportedFiles := PopulateFilesPropertyFromDataFiles([]DataFile{SimpleDataFile{"coco.csv"}}, dummyBatchKey)
 		assert.Len(t, unsupportedFiles, 1)
 		assert.Equal(t, FilesProperty{}, filesProperty)
 	})
 	t.Run("Should report unsupported files", func(t *testing.T) {
-		_, unsupportedFiles := PopulateFilesPropertyFromDataFiles([]DataFile{SimpleDataFile{"coco.csv"}}, dummyBatchKey.Path())
+		_, unsupportedFiles := PopulateFilesPropertyFromDataFiles([]DataFile{SimpleDataFile{"coco.csv"}}, dummyBatchKey)
 		assert.Equal(t, []string{dummyBatchKey.Path() + "coco.csv"}, unsupportedFiles)
 	})
 }

--- a/prepareimport/prepareimport.go
+++ b/prepareimport/prepareimport.go
@@ -33,13 +33,14 @@ func PrepareImport(pathname string, batchKey BatchKey, providedDateFinEffectif s
 		if err != nil {
 			return nil, errors.New("filter is missing: please include a filter or one effectif file")
 		}
-		effectifFilePath := path.Join(pathname, effectifFile)
-		filterFileName := path.Join(batchKey.Path(), "filter_siren_"+batchKey.String()+".csv")
+		effectifFilePath := path.Join(pathname, effectifFile.FilePathInParentBatch())
+		filterFile := newBatchFile(batchKey, "filter_siren_"+batchKey.String()+".csv")
+		filterFileName := filterFile.FilePath()
 		err = createFilterFromEffectif(path.Join(pathname, filterFileName), effectifFilePath)
 		if err != nil {
 			return nil, err
 		}
-		filesProperty["filter"] = append(filesProperty["filter"], filterFileName)
+		filesProperty["filter"] = append(filesProperty["filter"], filterFile)
 		dateFinEffectif, err = createfilter.DetectDateFinEffectif(effectifFilePath, createfilter.DefaultNbIgnoredCols) // TODO: éviter de lire le fichier Effectif deux fois
 		if err != nil {
 			return nil, err

--- a/prepareimport/prepareimport.go
+++ b/prepareimport/prepareimport.go
@@ -29,7 +29,12 @@ func PrepareImport(pathname string, batchKey BatchKey, providedDateFinEffectif s
 	var dateFinEffectif time.Time
 	if !filesProperty.HasFilterFile() {
 		if filesProperty.HasEffectifFile() {
-			dateFinEffectif, err = createFilterFromEffectif(filesProperty, batchKey, pathname)
+			err = createFilterFromEffectif(filesProperty, batchKey, pathname)
+			if err != nil {
+				return nil, err
+			}
+			effectifFile := path.Join(pathname, filesProperty["effectif"][0])
+			dateFinEffectif, err = createfilter.DetectDateFinEffectif(effectifFile, createfilter.DefaultNbIgnoredCols) // TODO: éviter de lire le fichier Effectif deux fois
 			if err != nil {
 				return nil, err
 			}
@@ -57,30 +62,23 @@ func PrepareImport(pathname string, batchKey BatchKey, providedDateFinEffectif s
 	}, err
 }
 
-func createFilterFromEffectif(filesProperty FilesProperty, batchKey BatchKey, pathname string) (dateFinEffectif time.Time, err error) {
+func createFilterFromEffectif(filesProperty FilesProperty, batchKey BatchKey, pathname string) (err error) {
 	if len(filesProperty["effectif"]) != 1 {
-		return dateFinEffectif, fmt.Errorf("generating a filter requires just 1 effectif file, found: %s", filesProperty["effectif"])
+		return fmt.Errorf("generating a filter requires just 1 effectif file, found: %s", filesProperty["effectif"])
 	}
 
 	filterFileName := path.Join(batchKey.Path(), "filter_siren_"+batchKey.String()+".csv")
 	filterFilePath := path.Join(pathname, filterFileName)
 	if fileExists(filterFilePath) {
-		return dateFinEffectif, errors.New("about to overwrite existing filter file: " + filterFilePath)
+		return errors.New("about to overwrite existing filter file: " + filterFilePath)
 	}
 	effectifFilePath := path.Join(pathname, filesProperty["effectif"][0])
 	err = createFilterFile(filterFilePath, effectifFilePath)
 	if err != nil {
-		return dateFinEffectif, err
+		return err
 	}
 	filesProperty["filter"] = append(filesProperty["filter"], filterFileName)
-
-	effectifFile := path.Join(pathname, filesProperty["effectif"][0])
-	// TODO: éviter de lire le fichier Effectif deux fois
-	dateFinEffectif, err = createfilter.DetectDateFinEffectif(effectifFile, createfilter.DefaultNbIgnoredCols)
-	if err != nil {
-		return dateFinEffectif, err
-	}
-	return dateFinEffectif, err
+	return err
 }
 
 func createFilterFile(filterFilePath string, effectifFilePath string) error {

--- a/prepareimport/prepareimport.go
+++ b/prepareimport/prepareimport.go
@@ -28,14 +28,16 @@ func PrepareImport(pathname string, batchKey BatchKey, providedDateFinEffectif s
 
 	var dateFinEffectif time.Time
 	filterFile, _ := filesProperty.GetFilterFile()
+
 	if filterFile == nil && batchKey.IsSubBatch() {
 		parentFilesProperty, _ := PopulateFilesProperty(pathname, newSafeBatchKey(batchKey.GetParentBatch()))
-		filterFile, err := parentFilesProperty.GetFilterFile()
-		if err != nil {
-			return nil, err
+		filterFile, err = parentFilesProperty.GetFilterFile()
+		if err == nil {
+			filesProperty["filter"] = append(filesProperty["filter"], filterFile)
 		}
-		filesProperty["filter"] = append(filesProperty["filter"], filterFile)
-	} else if filterFile == nil {
+	}
+
+	if filterFile == nil {
 		// Let's create a filter file from the effectif file
 		var err error
 		var effectifFile BatchFile

--- a/prepareimport/prepareimport.go
+++ b/prepareimport/prepareimport.go
@@ -14,9 +14,9 @@ import (
 // PrepareImport generates an Admin object from files found at given pathname of the file system.
 func PrepareImport(pathname string, batchKey BatchKey, providedDateFinEffectif string) (AdminObject, error) {
 
-	batchPath := path.Join(pathname, batchKey.String())
-	if _, err := ioutil.ReadDir(batchPath); err != nil {
-		return nil, fmt.Errorf("could not find directory %s in provided path", batchKey.String())
+	batchPath := getBatchPath(pathname, batchKey)
+	if _, err := ioutil.ReadDir(path.Join(pathname, batchPath)); err != nil {
+		return nil, fmt.Errorf("could not find directory %s in provided path", batchPath)
 	}
 
 	var err error
@@ -96,6 +96,13 @@ func createAndAppendFilter(filesProperty FilesProperty, batchKey BatchKey, pathn
 	}
 	filesProperty["filter"] = append(filesProperty["filter"], filterFileName)
 	return nil
+}
+
+func getBatchPath(pathname string, batchKey BatchKey) string {
+	if batchKey.IsSubBatch() {
+		return path.Join(batchKey.GetParentBatch(), batchKey.String())
+	}
+	return batchKey.String()
 }
 
 func fileExists(filename string) bool {

--- a/prepareimport/prepareimport.go
+++ b/prepareimport/prepareimport.go
@@ -27,7 +27,14 @@ func PrepareImport(pathname string, batchKey BatchKey, providedDateFinEffectif s
 	// - a dateFinEffectif value (provided as parameter, or detected from effectif file)
 
 	var dateFinEffectif time.Time
-	if !filesProperty.HasFilterFile() {
+	if !filesProperty.HasFilterFile() && batchKey.IsSubBatch() {
+		parentFilesProperty, _ := PopulateFilesProperty(pathname, newSafeBatchKey(batchKey.GetParentBatch()))
+		filterFile, err := parentFilesProperty.GetFilterFile()
+		if err != nil {
+			return nil, err
+		}
+		filesProperty["filter"] = append(filesProperty["filter"], filterFile)
+	} else if !filesProperty.HasFilterFile() {
 		// Let's create a filter file from the effectif file
 		var err error
 		var effectifFile BatchFile

--- a/prepareimport/prepareimport.go
+++ b/prepareimport/prepareimport.go
@@ -29,7 +29,14 @@ func PrepareImport(pathname string, batchKey BatchKey, providedDateFinEffectif s
 	var dateFinEffectif time.Time
 	if !filesProperty.HasFilterFile() {
 		// Let's create a filter file from the effectif file
-		effectifFile, err := filesProperty.GetEffectifFile()
+		var err error
+		var effectifFile BatchFile
+		if batchKey.IsSubBatch() {
+			parentFilesProperty, _ := PopulateFilesProperty(pathname, newSafeBatchKey(batchKey.GetParentBatch()))
+			effectifFile, err = parentFilesProperty.GetEffectifFile()
+		} else {
+			effectifFile, err = filesProperty.GetEffectifFile()
+		}
 		if err != nil {
 			return nil, errors.New("filter is missing: please include a filter or one effectif file")
 		}

--- a/prepareimport/prepareimport.go
+++ b/prepareimport/prepareimport.go
@@ -27,14 +27,15 @@ func PrepareImport(pathname string, batchKey BatchKey, providedDateFinEffectif s
 	// - a dateFinEffectif value (provided as parameter, or detected from effectif file)
 
 	var dateFinEffectif time.Time
-	if !filesProperty.HasFilterFile() && batchKey.IsSubBatch() {
+	filterFile, _ := filesProperty.GetFilterFile()
+	if filterFile == nil && batchKey.IsSubBatch() {
 		parentFilesProperty, _ := PopulateFilesProperty(pathname, newSafeBatchKey(batchKey.GetParentBatch()))
 		filterFile, err := parentFilesProperty.GetFilterFile()
 		if err != nil {
 			return nil, err
 		}
 		filesProperty["filter"] = append(filesProperty["filter"], filterFile)
-	} else if !filesProperty.HasFilterFile() {
+	} else if filterFile == nil {
 		// Let's create a filter file from the effectif file
 		var err error
 		var effectifFile BatchFile
@@ -48,7 +49,7 @@ func PrepareImport(pathname string, batchKey BatchKey, providedDateFinEffectif s
 			return nil, errors.New("filter is missing: batch should include a filter or one effectif file")
 		}
 		effectifFilePath := path.Join(pathname, effectifFile.FilePathInParentBatch())
-		filterFile := newBatchFile(batchKey, "filter_siren_"+batchKey.String()+".csv")
+		filterFile = newBatchFile(batchKey, "filter_siren_"+batchKey.String()+".csv")
 		filterFileName := filterFile.FilePath()
 		err = createFilterFromEffectif(path.Join(pathname, filterFileName), effectifFilePath)
 		if err != nil {

--- a/prepareimport/prepareimport.go
+++ b/prepareimport/prepareimport.go
@@ -51,7 +51,8 @@ func checkOrCreateFilterFromEffectif(filesProperty FilesProperty, batchKey Batch
 		if len(filesProperty["effectif"]) != 1 {
 			return dateFinEffectif, fmt.Errorf("generating a filter requires just 1 effectif file, found: %s", filesProperty["effectif"])
 		}
-		filterFileName, err := createFilterFile(filesProperty["effectif"], batchKey, pathname)
+		effectifFilePath := path.Join(pathname, filesProperty["effectif"][0])
+		filterFileName, err := createFilterFile(effectifFilePath, batchKey, pathname)
 		if err != nil {
 			return dateFinEffectif, err
 		}
@@ -70,11 +71,7 @@ func checkOrCreateFilterFromEffectif(filesProperty FilesProperty, batchKey Batch
 	return dateFinEffectif, err
 }
 
-func createFilterFile(effectifFiles []string, batchKey BatchKey, pathname string) (string, error) {
-	// make sure that there is only one effectif file
-	if len(effectifFiles) != 1 {
-		return "", errors.New("filter generation requires just 1 effectif file")
-	}
+func createFilterFile(effectifFilePath string, batchKey BatchKey, pathname string) (string, error) {
 	// create the filter file, if it does not already exist
 	filterFileName := path.Join(batchKey.Path(), "filter_siren_"+batchKey.String()+".csv")
 	filterFilePath := path.Join(pathname, filterFileName)
@@ -86,8 +83,8 @@ func createFilterFile(effectifFiles []string, batchKey BatchKey, pathname string
 		return "", err
 	}
 	err = createfilter.CreateFilter(
-		filterWriter,                          // output: the filter file
-		path.Join(pathname, effectifFiles[0]), // input: the effectif file
+		filterWriter,     // output: the filter file
+		effectifFilePath, // input: the effectif file
 		createfilter.DefaultNbMois,
 		createfilter.DefaultMinEffectif,
 		createfilter.DefaultNbIgnoredCols,

--- a/prepareimport/prepareimport.go
+++ b/prepareimport/prepareimport.go
@@ -33,12 +33,12 @@ func PrepareImport(pathname string, batchKey BatchKey, providedDateFinEffectif s
 
 	if effectifFile == nil && batchKey.IsSubBatch() {
 		parentFilesProperty, _ := PopulateFilesProperty(pathname, newSafeBatchKey(batchKey.GetParentBatch()))
-		effectifFile, err = parentFilesProperty.GetEffectifFile()
+		effectifFile, _ = parentFilesProperty.GetEffectifFile()
 	}
 
 	if filterFile == nil && batchKey.IsSubBatch() {
 		parentFilesProperty, _ := PopulateFilesProperty(pathname, newSafeBatchKey(batchKey.GetParentBatch()))
-		filterFile, err = parentFilesProperty.GetFilterFile()
+		filterFile, _ = parentFilesProperty.GetFilterFile()
 	}
 
 	if filterFile == nil {
@@ -46,11 +46,10 @@ func PrepareImport(pathname string, batchKey BatchKey, providedDateFinEffectif s
 			return nil, errors.New("filter is missing: batch should include a filter or one effectif file")
 		}
 		// Let's create a filter file from the effectif file
-		effectifFilePath := path.Join(pathname, effectifFile.FilePathInParentBatch())
+		effectifFilePath := path.Join(pathname, effectifFile.FilePath())
 		effectifBatch := effectifFile.BatchKey()
 		filterFile = newBatchFile(effectifBatch, "filter_siren_"+effectifBatch.String()+".csv")
-		err = createFilterFromEffectif(path.Join(pathname, filterFile.FilePath()), effectifFilePath)
-		if err != nil {
+		if err = createFilterFromEffectif(path.Join(pathname, filterFile.FilePath()), effectifFilePath); err != nil {
 			return nil, err
 		}
 		dateFinEffectif, err = createfilter.DetectDateFinEffectif(effectifFilePath, createfilter.DefaultNbIgnoredCols) // TODO: éviter de lire le fichier Effectif deux fois

--- a/prepareimport/prepareimport.go
+++ b/prepareimport/prepareimport.go
@@ -3,6 +3,7 @@ package prepareimport
 import (
 	"errors"
 	"fmt"
+	"io/ioutil"
 	"os"
 	"path"
 	"time"
@@ -12,6 +13,12 @@ import (
 
 // PrepareImport generates an Admin object from files found at given pathname of the file system.
 func PrepareImport(pathname string, batchKey BatchKey, providedDateFinEffectif string) (AdminObject, error) {
+
+	batchPath := path.Join(pathname, batchKey.String())
+	if _, err := ioutil.ReadDir(batchPath); err != nil {
+		return nil, fmt.Errorf("could not find directory %s in provided path", batchKey.String())
+	}
+
 	var err error
 	filesProperty, unsupportedFiles := PopulateFilesProperty(pathname, batchKey)
 

--- a/prepareimport/prepareimport.go
+++ b/prepareimport/prepareimport.go
@@ -38,7 +38,7 @@ func PrepareImport(pathname string, batchKey BatchKey, providedDateFinEffectif s
 			effectifFile, err = filesProperty.GetEffectifFile()
 		}
 		if err != nil {
-			return nil, errors.New("filter is missing: please include a filter or one effectif file")
+			return nil, errors.New("filter is missing: batch should include a filter or one effectif file")
 		}
 		effectifFilePath := path.Join(pathname, effectifFile.FilePathInParentBatch())
 		filterFile := newBatchFile(batchKey, "filter_siren_"+batchKey.String()+".csv")

--- a/prepareimport/prepareimport_test.go
+++ b/prepareimport/prepareimport_test.go
@@ -43,14 +43,14 @@ func TestPrepareImport(t *testing.T) {
 	t.Run("Should warn if no filter is provided", func(t *testing.T) {
 		dir := CreateTempFiles(t, dummyBatchKey, []string{"Sigfaibles_debits.csv"})
 		_, err := PrepareImport(dir, dummyBatchKey, dummyDateFinEffectif)
-		expected := "filter is missing: please include a filter or an effectif file"
+		expected := "filter is missing: please include a filter or one effectif file"
 		assert.Equal(t, expected, err.Error())
 	})
 
 	t.Run("Should warn if 2 effectif files are provided", func(t *testing.T) {
 		dir := CreateTempFiles(t, dummyBatchKey, []string{"Sigfaible_effectif_siret.csv", "Sigfaible_effectif_siret2.csv"})
 		_, err := PrepareImport(dir, dummyBatchKey, dummyDateFinEffectif)
-		expected := "generating a filter requires just 1 effectif file, found: [/1802/Sigfaible_effectif_siret.csv /1802/Sigfaible_effectif_siret2.csv]"
+		expected := "filter is missing: please include a filter or one effectif file"
 		assert.Equal(t, expected, err.Error())
 	})
 

--- a/prepareimport/prepareimport_test.go
+++ b/prepareimport/prepareimport_test.go
@@ -23,6 +23,15 @@ func TestReadFilenames(t *testing.T) {
 }
 
 func TestPrepareImport(t *testing.T) {
+	t.Run("Should warn if the name of the directory does not match the name of the batch", func(t *testing.T) {
+		batch := newSafeBatchKey("1803")
+		CreateTempFiles(t, batch, []string{})
+		wrongDir := CreateTempFiles(t, dummyBatchKey, []string{})
+		_, err := PrepareImport(wrongDir, batch, "")
+		expected := "the name of the directory does not match the name of the batch"
+		assert.Equal(t, expected, err.Error())
+	})
+
 	t.Run("Should warn if no filter is provided", func(t *testing.T) {
 		dir := CreateTempFiles(t, dummyBatchKey, []string{"Sigfaibles_debits.csv"})
 		_, err := PrepareImport(dir, dummyBatchKey, dummyDateFinEffectif)

--- a/prepareimport/prepareimport_test.go
+++ b/prepareimport/prepareimport_test.go
@@ -3,7 +3,6 @@ package prepareimport
 import (
 	"errors"
 	"io/ioutil"
-	"os"
 	"path"
 	"path/filepath"
 	"testing"
@@ -71,18 +70,18 @@ func TestPrepareImport(t *testing.T) {
 		}
 	})
 
-	t.Run("Should detect the effectif file of the parent batch, given we are generating a sub-batch", func(t *testing.T) {
-		subBatch := newSafeBatchKey("1803_01")
-		parentBatch := subBatch.GetParentBatch()
-		parentDir := CreateTempFiles(t, newSafeBatchKey(parentBatch), []string{"filter_2002.csv"})
-		subBatchDir := filepath.Join(parentDir, parentBatch, subBatch.String())
-		os.Mkdir(subBatchDir, 0777)
-		res, err := PrepareImport(parentDir, subBatch, "")
-		expected := FilesProperty{filter: []string{dummyBatchKey.Path() + "filter_2002.csv"}}
-		if assert.NoError(t, err) {
-			assert.Equal(t, expected, res["files"])
-		}
-	})
+	// t.Run("Should detect the effectif file of the parent batch, given we are generating a sub-batch", func(t *testing.T) {
+	// 	subBatch := newSafeBatchKey("1803_01")
+	// 	parentBatch := subBatch.GetParentBatch()
+	// 	parentDir := CreateTempFiles(t, newSafeBatchKey(parentBatch), []string{"filter_2002.csv"})
+	// 	subBatchDir := filepath.Join(parentDir, parentBatch, subBatch.String())
+	// 	os.Mkdir(subBatchDir, 0777)
+	// 	res, err := PrepareImport(parentDir, subBatch, "")
+	// 	expected := FilesProperty{filter: []string{dummyBatchKey.Path() + "filter_2002.csv"}}
+	// 	if assert.NoError(t, err) {
+	// 		assert.Equal(t, expected, res["files"])
+	// 	}
+	// })
 
 	t.Run("Should return an _id property", func(t *testing.T) {
 		batch := newSafeBatchKey("1802")

--- a/prepareimport/prepareimport_test.go
+++ b/prepareimport/prepareimport_test.go
@@ -75,18 +75,19 @@ func TestPrepareImport(t *testing.T) {
 		// Set expectations
 		subBatch := newSafeBatchKey("1803_01")
 		parentBatch := newSafeBatchKey(subBatch.GetParentBatch())
-		filterFile := newBatchFile(parentBatch, "filter_siren_1803.csv")
+		filterFile := newBatchFile(subBatch, "filter_siren_1803.csv")
+		parentFilterFile := newBatchFile(parentBatch, "filter_siren_1803.csv")
 		expectedFilesProp := FilesProperty{filter: {filterFile}}
 		// Setup test environment
-		parentDir := CreateTempFiles(t, parentBatch, []string{filterFile.FileName()})
+		parentDir := CreateTempFiles(t, parentBatch, []string{parentFilterFile.FileName()})
 		subBatchDir := filepath.Join(parentDir, parentBatch.String(), subBatch.String())
 		os.Mkdir(subBatchDir, 0777)
 		// Run the test
 		res, err := PrepareImport(parentDir, subBatch, "2018-03-01")
 		if assert.NoError(t, err) {
 			assert.Equal(t, expectedFilesProp, res["files"])
-			assert.Equal(t, subBatch.Path()+filterFile.FileName(), filterFile.FilePath())
-			assert.True(t, fileExists(filterFile.FilePath()))
+			duplicatedFilePath := path.Join(parentDir, parentBatch.GetParentBatch(), filterFile.FilePath())
+			assert.True(t, fileExists(duplicatedFilePath))
 		}
 	})
 

--- a/prepareimport/prepareimport_test.go
+++ b/prepareimport/prepareimport_test.go
@@ -84,8 +84,19 @@ func TestPrepareImport(t *testing.T) {
 		}
 	})
 
-	// TODO: Should detect the effectif file of the parent batch, given we are generating a sub-batch
-	// parentDir := CreateTempFiles(t, newSafeBatchKey(parentBatch), []string{"Sigfaible_effectif_siret.csv"})
+	t.Run("Should infer the filter and date_fin_effectif from the effectif file of the parent batch, given we are generating a sub-batch", func(t *testing.T) {
+		subBatch := newSafeBatchKey("1803_01")
+		parentBatch := subBatch.GetParentBatch()
+		parentDir := CreateTempFiles(t, newSafeBatchKey(parentBatch), []string{"Sigfaible_effectif_siret.csv"})
+		subBatchDir := filepath.Join(parentDir, parentBatch, subBatch.String())
+		os.Mkdir(subBatchDir, 0777)
+		expectedFilesProp := FilesProperty{filter: {newBatchFile(newSafeBatchKey(parentBatch), "filter_siren_1803.csv")}}
+		res, err := PrepareImport(parentDir, subBatch, "")
+		if assert.NoError(t, err) {
+			assert.Equal(t, expectedFilesProp, res["files"])
+			assert.Equal(t, "2018-03-01", res["params"].(ParamProperty).DateFinEffectif)
+		}
+	})
 
 	t.Run("Should return an _id property", func(t *testing.T) {
 		batch := newSafeBatchKey("1802")

--- a/prepareimport/prepareimport_test.go
+++ b/prepareimport/prepareimport_test.go
@@ -84,19 +84,19 @@ func TestPrepareImport(t *testing.T) {
 		}
 	})
 
-	t.Run("Should infer the filter and date_fin_effectif from the effectif file of the parent batch, given we are generating a sub-batch", func(t *testing.T) {
-		subBatch := newSafeBatchKey("1803_01")
-		parentBatch := subBatch.GetParentBatch()
-		parentDir := CreateTempFiles(t, newSafeBatchKey(parentBatch), []string{"Sigfaible_effectif_siret.csv"})
-		subBatchDir := filepath.Join(parentDir, parentBatch, subBatch.String())
-		os.Mkdir(subBatchDir, 0777)
-		expectedFilesProp := FilesProperty{filter: {newBatchFile(newSafeBatchKey(parentBatch), "filter_siren_1803.csv")}}
-		res, err := PrepareImport(parentDir, subBatch, "")
-		if assert.NoError(t, err) {
-			assert.Equal(t, expectedFilesProp, res["files"])
-			assert.Equal(t, "2018-03-01", res["params"].(ParamProperty).DateFinEffectif)
-		}
-	})
+	// t.Run("Should infer the filter and date_fin_effectif from the effectif file of the parent batch, given we are generating a sub-batch", func(t *testing.T) {
+	// 	subBatch := newSafeBatchKey("1803_01")
+	// 	parentBatch := subBatch.GetParentBatch()
+	// 	parentDir := CreateTempFiles(t, newSafeBatchKey(parentBatch), []string{"Sigfaible_effectif_siret.csv"})
+	// 	subBatchDir := filepath.Join(parentDir, parentBatch, subBatch.String())
+	// 	os.Mkdir(subBatchDir, 0777)
+	// 	expectedFilesProp := FilesProperty{filter: {newBatchFile(newSafeBatchKey(parentBatch), "filter_siren_1803.csv")}}
+	// 	res, err := PrepareImport(parentDir, subBatch, "")
+	// 	if assert.NoError(t, err) {
+	// 		assert.Equal(t, expectedFilesProp, res["files"])
+	// 		assert.Equal(t, "2018-03-01", res["params"].(ParamProperty).DateFinEffectif)
+	// 	}
+	// })
 
 	t.Run("Should return an _id property", func(t *testing.T) {
 		batch := newSafeBatchKey("1802")

--- a/prepareimport/prepareimport_test.go
+++ b/prepareimport/prepareimport_test.go
@@ -91,6 +91,26 @@ func TestPrepareImport(t *testing.T) {
 		}
 	})
 
+	t.Run("Should infer date_fin_effectif from the effectif file", func(t *testing.T) {
+		// Set expectations
+		effectifFile := dummyBatchFile("Sigfaible_effectif_siret.csv")
+		providedDateFinEffetif := ""
+		expectedDateFinEffectif := NewDateFinEffectif(time.Date(2020, time.Month(1), 1, 0, 0, 0, 0, time.UTC)).MongoDate()
+		// Setup test environment
+		data, err := ioutil.ReadFile("../createfilter/test_data.csv")
+		if err != nil {
+			t.Fatal(err)
+		}
+		parentDir := CreateTempFilesWithContent(t, dummyBatchKey, map[string][]byte{
+			effectifFile.Name(): data,
+		})
+		// Run the test
+		res, err := PrepareImport(parentDir, dummyBatchKey, providedDateFinEffetif)
+		if assert.NoError(t, err) {
+			assert.Equal(t, expectedDateFinEffectif, res["param"].(ParamProperty).DateFinEffectif)
+		}
+	})
+
 	t.Run("Should infer the filter and date_fin_effectif from the effectif file of the parent batch, given we are generating a sub-batch", func(t *testing.T) {
 		// Set expectations
 		subBatch := newSafeBatchKey("1803_01")

--- a/prepareimport/prepareimport_test.go
+++ b/prepareimport/prepareimport_test.go
@@ -31,6 +31,15 @@ func TestPrepareImport(t *testing.T) {
 		assert.Equal(t, expected, err.Error())
 	})
 
+	t.Run("Should warn if the sub-batch was not found in the specified directory", func(t *testing.T) {
+		subBatch := newSafeBatchKey("1803_01")
+		parentBatch := newSafeBatchKey("1803")
+		parentDir := CreateTempFiles(t, parentBatch, []string{})
+		_, err := PrepareImport(parentDir, subBatch, "")
+		expected := "could not find directory 1803/01 in provided path"
+		assert.Equal(t, expected, err.Error())
+	})
+
 	t.Run("Should warn if no filter is provided", func(t *testing.T) {
 		dir := CreateTempFiles(t, dummyBatchKey, []string{"Sigfaibles_debits.csv"})
 		_, err := PrepareImport(dir, dummyBatchKey, dummyDateFinEffectif)

--- a/prepareimport/prepareimport_test.go
+++ b/prepareimport/prepareimport_test.go
@@ -77,10 +77,10 @@ func TestPrepareImport(t *testing.T) {
 		parentDir := CreateTempFiles(t, newSafeBatchKey(parentBatch), []string{"filter_siren_1803.csv"})
 		subBatchDir := filepath.Join(parentDir, parentBatch, subBatch.String())
 		os.Mkdir(subBatchDir, 0777)
-		res, err := PrepareImport(parentDir, subBatch, "")
-		expected := FilesProperty{filter: {dummyBatchFile("filter_siren_1803.csv")}}
+		expectedFilesProp := FilesProperty{filter: {newBatchFile(newSafeBatchKey(parentBatch), "filter_siren_1803.csv")}}
+		res, err := PrepareImport(parentDir, subBatch, "2018-03-01")
 		if assert.NoError(t, err) {
-			assert.Equal(t, expected, res["files"])
+			assert.Equal(t, expectedFilesProp, res["files"])
 		}
 	})
 

--- a/prepareimport/prepareimport_test.go
+++ b/prepareimport/prepareimport_test.go
@@ -79,14 +79,14 @@ func TestPrepareImport(t *testing.T) {
 		parentFilterFile := newBatchFile(parentBatch, "filter_siren_1803.csv")
 		expectedFilesProp := FilesProperty{filter: {filterFile}}
 		// Setup test environment
-		parentDir := CreateTempFiles(t, parentBatch, []string{parentFilterFile.FileName()})
+		parentDir := CreateTempFiles(t, parentBatch, []string{parentFilterFile.Name()})
 		subBatchDir := filepath.Join(parentDir, parentBatch.String(), subBatch.String())
 		os.Mkdir(subBatchDir, 0777)
 		// Run the test
 		res, err := PrepareImport(parentDir, subBatch, "2018-03-01")
 		if assert.NoError(t, err) {
 			assert.Equal(t, expectedFilesProp, res["files"])
-			duplicatedFilePath := path.Join(parentDir, parentBatch.GetParentBatch(), filterFile.FilePath())
+			duplicatedFilePath := path.Join(parentDir, parentBatch.GetParentBatch(), filterFile.Path())
 			assert.True(t, fileExists(duplicatedFilePath))
 		}
 	})
@@ -105,7 +105,7 @@ func TestPrepareImport(t *testing.T) {
 			t.Fatal(err)
 		}
 		parentDir := CreateTempFilesWithContent(t, parentBatch, map[string][]byte{
-			parentEffectifFile.FileName(): data,
+			parentEffectifFile.Name(): data,
 		})
 		subBatchDir := filepath.Join(parentDir, parentBatch.String(), subBatch.String())
 		os.Mkdir(subBatchDir, 0777)
@@ -113,7 +113,7 @@ func TestPrepareImport(t *testing.T) {
 		res, err := PrepareImport(parentDir, subBatch, "")
 		if assert.NoError(t, err) {
 			assert.Equal(t, expectedFilesProp, res["files"])
-			duplicatedFilePath := path.Join(parentDir, parentBatch.GetParentBatch(), filterFile.FilePath())
+			duplicatedFilePath := path.Join(parentDir, parentBatch.GetParentBatch(), filterFile.Path())
 			assert.True(t, fileExists(duplicatedFilePath))
 			assert.Equal(t, expectedDateFinEffectif, res["param"].(ParamProperty).DateFinEffectif)
 		}

--- a/prepareimport/prepareimport_test.go
+++ b/prepareimport/prepareimport_test.go
@@ -65,7 +65,7 @@ func TestPrepareImport(t *testing.T) {
 	t.Run("Should return a json with one file", func(t *testing.T) {
 		dir := CreateTempFiles(t, dummyBatchKey, []string{"filter_2002.csv"})
 		res, err := PrepareImport(dir, dummyBatchKey, dummyDateFinEffectif)
-		expected := FilesProperty{filter: []string{dummyBatchKey.Path() + "filter_2002.csv"}}
+		expected := FilesProperty{filter: {dummyBatchFile("filter_2002.csv")}}
 		if assert.NoError(t, err) {
 			assert.Equal(t, expected, res["files"])
 		}
@@ -78,7 +78,7 @@ func TestPrepareImport(t *testing.T) {
 		subBatchDir := filepath.Join(parentDir, parentBatch, subBatch.String())
 		os.Mkdir(subBatchDir, 0777)
 		res, err := PrepareImport(parentDir, subBatch, "")
-		expected := FilesProperty{filter: []string{dummyBatchKey.Path() + "filter_2002.csv"}}
+		expected := FilesProperty{filter: {dummyBatchFile("filter_2002.csv")}}
 		if assert.NoError(t, err) {
 			assert.Equal(t, expected, res["files"])
 		}
@@ -115,7 +115,7 @@ func TestPrepareImport(t *testing.T) {
 			}
 
 			res, err := PrepareImport(dir, dummyBatchKey, dummyDateFinEffectif)
-			expected := []string{dummyBatchKey.Path() + testCase.id}
+			expected := []BatchFile{dummyBatchFile(testCase.id)}
 			if assert.NoError(t, err) {
 				assert.Equal(t, expected, res["files"].(FilesProperty)[testCase.filetype])
 			}
@@ -147,17 +147,17 @@ func TestPrepareImport(t *testing.T) {
 			"Sigfaible_effectif_siret.csv": data,
 		})
 		adminObject, err := PrepareImport(dir, dummyBatchKey, "")
-		filterFileName := dummyBatchKey.Path() + "filter_siren_" + dummyBatchKey.String() + ".csv"
+		filterFileName := "filter_siren_" + dummyBatchKey.String() + ".csv"
 		expected := FilesProperty{
-			"effectif": []string{dummyBatchKey.Path() + "Sigfaible_effectif_siret.csv"},
-			"filter":   []string{filterFileName},
+			"effectif": {dummyBatchFile("Sigfaible_effectif_siret.csv")},
+			"filter":   {dummyBatchFile(filterFileName)},
 		}
 		// check that the filter is listed in the "files" property
 		if assert.NoError(t, err) {
 			assert.Equal(t, expected, adminObject["files"])
 		}
 		// check that the filter file exists
-		filterFilePath := path.Join(dir, filterFileName)
+		filterFilePath := path.Join(dir, dummyBatchKey.Path(), filterFileName)
 		assert.True(t, fileExists(filterFilePath), "the filter file was not found: "+filterFilePath)
 		// check that date_fin_effectif was detected from the effectif file
 		validDateFinEffectif := time.Date(2020, time.Month(1), 1, 0, 0, 0, 0, time.UTC)

--- a/prepareimport/prepareimport_test.go
+++ b/prepareimport/prepareimport_test.go
@@ -36,7 +36,7 @@ func TestPrepareImport(t *testing.T) {
 		parentBatch := newSafeBatchKey("1803")
 		parentDir := CreateTempFiles(t, parentBatch, []string{})
 		_, err := PrepareImport(parentDir, subBatch, "")
-		expected := "could not find directory 1803/01 in provided path"
+		expected := "could not find directory 1803/1803_01 in provided path"
 		assert.Equal(t, expected, err.Error())
 	})
 
@@ -60,6 +60,15 @@ func TestPrepareImport(t *testing.T) {
 		expected := "date_fin_effectif is missing or invalid: "
 		assert.Equal(t, expected, err.Error())
 	})
+
+	/*
+		t.Run("Should detect the effectif file of the parent batch, given we are ", func(t *testing.T) {
+			dir := CreateTempFiles(t, dummyBatchKey, []string{"filter_2002.csv"})
+			_, err := PrepareImport(dir, dummyBatchKey, "")
+			expected := "date_fin_effectif is missing or invalid: "
+			assert.Equal(t, expected, err.Error())
+		})
+	*/
 
 	t.Run("Should return a json with one file", func(t *testing.T) {
 		dir := CreateTempFiles(t, dummyBatchKey, []string{"filter_2002.csv"})

--- a/prepareimport/prepareimport_test.go
+++ b/prepareimport/prepareimport_test.go
@@ -3,6 +3,7 @@ package prepareimport
 import (
 	"errors"
 	"io/ioutil"
+	"os"
 	"path"
 	"path/filepath"
 	"testing"
@@ -70,18 +71,18 @@ func TestPrepareImport(t *testing.T) {
 		}
 	})
 
-	// t.Run("Should detect the effectif file of the parent batch, given we are generating a sub-batch", func(t *testing.T) {
-	// 	subBatch := newSafeBatchKey("1803_01")
-	// 	parentBatch := subBatch.GetParentBatch()
-	// 	parentDir := CreateTempFiles(t, newSafeBatchKey(parentBatch), []string{"filter_2002.csv"})
-	// 	subBatchDir := filepath.Join(parentDir, parentBatch, subBatch.String())
-	// 	os.Mkdir(subBatchDir, 0777)
-	// 	res, err := PrepareImport(parentDir, subBatch, "")
-	// 	expected := FilesProperty{filter: []string{dummyBatchKey.Path() + "filter_2002.csv"}}
-	// 	if assert.NoError(t, err) {
-	// 		assert.Equal(t, expected, res["files"])
-	// 	}
-	// })
+	t.Run("Should detect the effectif file of the parent batch, given we are generating a sub-batch", func(t *testing.T) {
+		subBatch := newSafeBatchKey("1803_01")
+		parentBatch := subBatch.GetParentBatch()
+		parentDir := CreateTempFiles(t, newSafeBatchKey(parentBatch), []string{"filter_2002.csv"})
+		subBatchDir := filepath.Join(parentDir, parentBatch, subBatch.String())
+		os.Mkdir(subBatchDir, 0777)
+		res, err := PrepareImport(parentDir, subBatch, "")
+		expected := FilesProperty{filter: []string{dummyBatchKey.Path() + "filter_2002.csv"}}
+		if assert.NoError(t, err) {
+			assert.Equal(t, expected, res["files"])
+		}
+	})
 
 	t.Run("Should return an _id property", func(t *testing.T) {
 		batch := newSafeBatchKey("1802")

--- a/prepareimport/prepareimport_test.go
+++ b/prepareimport/prepareimport_test.go
@@ -71,18 +71,21 @@ func TestPrepareImport(t *testing.T) {
 		}
 	})
 
-	t.Run("Should detect the effectif file of the parent batch, given we are generating a sub-batch", func(t *testing.T) {
+	t.Run("Should detect the filter file of the parent batch, given we are generating a sub-batch", func(t *testing.T) {
 		subBatch := newSafeBatchKey("1803_01")
 		parentBatch := subBatch.GetParentBatch()
-		parentDir := CreateTempFiles(t, newSafeBatchKey(parentBatch), []string{"filter_2002.csv"})
+		parentDir := CreateTempFiles(t, newSafeBatchKey(parentBatch), []string{"filter_siren_1803.csv"})
 		subBatchDir := filepath.Join(parentDir, parentBatch, subBatch.String())
 		os.Mkdir(subBatchDir, 0777)
 		res, err := PrepareImport(parentDir, subBatch, "")
-		expected := FilesProperty{filter: {dummyBatchFile("filter_2002.csv")}}
+		expected := FilesProperty{filter: {dummyBatchFile("filter_siren_1803.csv")}}
 		if assert.NoError(t, err) {
 			assert.Equal(t, expected, res["files"])
 		}
 	})
+
+	// TODO: Should detect the effectif file of the parent batch, given we are generating a sub-batch
+	// parentDir := CreateTempFiles(t, newSafeBatchKey(parentBatch), []string{"Sigfaible_effectif_siret.csv"})
 
 	t.Run("Should return an _id property", func(t *testing.T) {
 		batch := newSafeBatchKey("1802")

--- a/prepareimport/prepareimport_test.go
+++ b/prepareimport/prepareimport_test.go
@@ -91,19 +91,19 @@ func TestPrepareImport(t *testing.T) {
 		}
 	})
 
-	// t.Run("Should infer the filter and date_fin_effectif from the effectif file of the parent batch, given we are generating a sub-batch", func(t *testing.T) {
-	// 	subBatch := newSafeBatchKey("1803_01")
-	// 	parentBatch := subBatch.GetParentBatch()
-	// 	parentDir := CreateTempFiles(t, newSafeBatchKey(parentBatch), []string{"Sigfaible_effectif_siret.csv"})
-	// 	subBatchDir := filepath.Join(parentDir, parentBatch, subBatch.String())
-	// 	os.Mkdir(subBatchDir, 0777)
-	// 	expectedFilesProp := FilesProperty{filter: {newBatchFile(newSafeBatchKey(parentBatch), "filter_siren_1803.csv")}}
-	// 	res, err := PrepareImport(parentDir, subBatch, "")
-	// 	if assert.NoError(t, err) {
-	// 		assert.Equal(t, expectedFilesProp, res["files"])
-	// 		assert.Equal(t, "2018-03-01", res["params"].(ParamProperty).DateFinEffectif)
-	// 	}
-	// })
+	t.Run("Should infer the filter and date_fin_effectif from the effectif file of the parent batch, given we are generating a sub-batch", func(t *testing.T) {
+		subBatch := newSafeBatchKey("1803_01")
+		parentBatch := subBatch.GetParentBatch()
+		parentDir := CreateTempFiles(t, newSafeBatchKey(parentBatch), []string{"Sigfaible_effectif_siret.csv"})
+		subBatchDir := filepath.Join(parentDir, parentBatch, subBatch.String())
+		os.Mkdir(subBatchDir, 0777)
+		expectedFilesProp := FilesProperty{filter: {newBatchFile(newSafeBatchKey(parentBatch), "filter_siren_1803.csv")}}
+		res, err := PrepareImport(parentDir, subBatch, "")
+		if assert.NoError(t, err) {
+			assert.Equal(t, expectedFilesProp, res["files"])
+			assert.Equal(t, "2018-03-01", res["params"].(ParamProperty).DateFinEffectif)
+		}
+	})
 
 	t.Run("Should return an _id property", func(t *testing.T) {
 		batch := newSafeBatchKey("1802")

--- a/prepareimport/prepareimport_test.go
+++ b/prepareimport/prepareimport_test.go
@@ -44,14 +44,14 @@ func TestPrepareImport(t *testing.T) {
 	t.Run("Should warn if no filter is provided", func(t *testing.T) {
 		dir := CreateTempFiles(t, dummyBatchKey, []string{"Sigfaibles_debits.csv"})
 		_, err := PrepareImport(dir, dummyBatchKey, dummyDateFinEffectif)
-		expected := "filter is missing: please include a filter or one effectif file"
+		expected := "filter is missing: batch should include a filter or one effectif file"
 		assert.Equal(t, expected, err.Error())
 	})
 
 	t.Run("Should warn if 2 effectif files are provided", func(t *testing.T) {
 		dir := CreateTempFiles(t, dummyBatchKey, []string{"Sigfaible_effectif_siret.csv", "Sigfaible_effectif_siret2.csv"})
 		_, err := PrepareImport(dir, dummyBatchKey, dummyDateFinEffectif)
-		expected := "filter is missing: please include a filter or one effectif file"
+		expected := "filter is missing: batch should include a filter or one effectif file"
 		assert.Equal(t, expected, err.Error())
 	})
 

--- a/prepareimport/prepareimport_test.go
+++ b/prepareimport/prepareimport_test.go
@@ -23,12 +23,11 @@ func TestReadFilenames(t *testing.T) {
 }
 
 func TestPrepareImport(t *testing.T) {
-	t.Run("Should warn if the name of the directory does not match the name of the batch", func(t *testing.T) {
-		batch := newSafeBatchKey("1803")
-		CreateTempFiles(t, batch, []string{})
-		wrongDir := CreateTempFiles(t, dummyBatchKey, []string{})
-		_, err := PrepareImport(wrongDir, batch, "")
-		expected := "the name of the directory does not match the name of the batch"
+	t.Run("Should warn if the batch was not found in the specified directory", func(t *testing.T) {
+		wantedBatch := newSafeBatchKey("1803") // different of dummyBatchKey
+		parentDir := CreateTempFiles(t, dummyBatchKey, []string{})
+		_, err := PrepareImport(parentDir, wantedBatch, "")
+		expected := "could not find directory 1803 in provided path"
 		assert.Equal(t, expected, err.Error())
 	})
 


### PR DESCRIPTION
Suite de PR #42. Contribue à https://github.com/signaux-faibles/opensignauxfaibles/issues/167.

## Problème

Pour importer un sous-batch (c.a.d. un ensemble de fichiers de données basé sur le même périmètre/filtre que le précédent import), il faut ajouter à la main le fichier `filter` + la date de fin effectif employés lors du précédent import. Au delà d'être pénible, le fait d'effectuer cette opération à la main augmente le risque de mauvaise manipulation, et donc d'altération/perte de données dans la base de production.

## Solution proposée

Supposons la hiérarchie suivante de répertoires batches:

```
|
|-- batches
|     |-- 1802
|     |-- 1802
|     |    |-- 1802_01
```

Désormais, depuis le répertoire `batches`, on peut appeler:

```sh
$ prepare-import --batch 1802 # ... puis ...
$ prepare-import --batch 1802_01
```

=> Les informations suivantes peuvent être inférées automatiquement:

- `filter`: hérité ou généré depuis le fichier `effectif` du batch parent
- `date_fin_effectif`: détecté depuis le fichier `effectif` du batch parent

Note: quand on appelle `prepare-import` sur un sous-batch, le fichier `filter` du batch parent sera copié dans le répertoire du sous-batch, et intégré dans l'objet Admin résultant, en conservant le même nom de fichier.

## Prochaines étapes à envisager

- optimisation: ne pas avoir à lire le fichier effectif une deuxième fois, juste pour récupérer la date de fin effectif.
- simplification: retirer le paramètre `path` et considérer que le script sera lancé depuis le répertoire contenant tous les batches.