### PR TITLE
fix(createfilter): Ne pas considérer le département comme valeur d'effectif

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -41,6 +41,7 @@ jobs:
 
       - name: Install test dependencies
         run: |
+          sudo apt-get upgrade --fix-missing
           sudo apt-get install -y gnumeric # more specifically: "ssconvert", for filter_to_diane
 
       - name: Test

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   build:
     name: Build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Set up Go 1.14
         uses: actions/setup-go@v1

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -41,8 +41,7 @@ jobs:
 
       - name: Install test dependencies
         run: |
-          sudo apt-get upgrade --fix-missing
-          sudo apt-get install -y gnumeric # more specifically: "ssconvert", for filter_to_diane
+          sudo apt-get install -y --no-install-recommends gnumeric # more specifically: "ssconvert", for filter_to_diane
 
       - name: Test
         run: go test ./... -v -coverprofile=coverage.out

--- a/createfilter/main.go
+++ b/createfilter/main.go
@@ -24,6 +24,9 @@ const DefaultMinEffectif = 10
 // DefaultNbIgnoredCols is the default number of rightmost columns that don't contain effectif data.
 const DefaultNbIgnoredCols = 2
 
+// NbLeadingColsToSkip is the number of leftmost columns that don't contain effectif data.
+const NbLeadingColsToSkip = 5 // column names: "compte", "siret", "rais_soc", "ape_ins" and "dep"
+
 // Implementation of the create_filter command.
 func main() {
 
@@ -87,7 +90,7 @@ func outputPerimeter(r *csv.Reader, w io.Writer, nbMois, minEffectif, nIgnoredCo
 			log.Panic(err)
 		}
 		shouldKeep := len(record[1]) == 14 &&
-			isInsidePerimeter(record[0:len(record)-nIgnoredCols], nbMois, minEffectif)
+			isInsidePerimeter(record[NbLeadingColsToSkip:len(record)-nIgnoredCols], nbMois, minEffectif)
 
 		if shouldKeep {
 			perimeter = append(perimeter, record[1])

--- a/createfilter/main_test.go
+++ b/createfilter/main_test.go
@@ -41,7 +41,7 @@ func TestOutputPerimeter(t *testing.T) {
 		// setup conditions and expectations
 		minEffectif := 10
 		nbIgnoredCols := 2 // "base" and "UR_EMET"
-		expectedSirens := []string{"22222222222222", "33333333333333"}
+		expectedSirens := []string{"222222222", "333333333"}
 		effectifData := strings.Join([]string{
 			"compte;siret;rais_soc;ape_ins;dep;eff201011;eff201012;base;UR_EMET",
 			"000000000000000000;00000000000000;ENTREPRISE;1234Z;75;4;4;116;075077",   // ❌ 75 ≥ 10, mais ce n'est pas un effectif

--- a/createfilter/main_test.go
+++ b/createfilter/main_test.go
@@ -57,7 +57,8 @@ func TestOutputPerimeter(t *testing.T) {
 		outputPerimeter(reader, writer, DefaultNbMois, minEffectif, nbIgnoredCols)
 		writer.Flush()
 		// assert
-		assert.Equal(t, expectedSirens, strings.Split(output.String(), "\n"))
+		actualSirens := strings.Split(strings.TrimSpace(output.String()), "\n")
+		assert.Equal(t, expectedSirens, actualSirens)
 	})
 }
 


### PR DESCRIPTION
Contribue à https://github.com/signaux-faibles/opensignauxfaibles/issues/199.

En écrivant un test unitaire, je me suis rendu compte que la valeur `75` – rattachée à la colonne dep, comme _département_ – était considérée comme valeur d’effectif ≥10.

Si ce bug est avéré, il est probable que nous ayons importé plus de petites entreprises que voulu.