### PR TITLE
fix(filter): Dé-duplication des SIRENs dans le filtre/périmètre

### DIFF
--- a/createfilter/main.go
+++ b/createfilter/main.go
@@ -75,8 +75,8 @@ func initializeEffectifReader(f *os.File) *csv.Reader {
 }
 
 func outputPerimeter(r *csv.Reader, w io.Writer, nbMois, minEffectif, nIgnoredCols int) {
-	detectedSirens := map[string]bool{}
-	_, err := r.Read() // en tête
+	detectedSirens := map[string]struct{}{} // smaller memory footprint than map[string]bool
+	_, err := r.Read()                      // en tête
 	if err != nil {
 		log.Panic(err)
 	}
@@ -94,9 +94,10 @@ func outputPerimeter(r *csv.Reader, w io.Writer, nbMois, minEffectif, nIgnoredCo
 			isInsidePerimeter(record[NbLeadingColsToSkip:len(record)-nIgnoredCols], nbMois, minEffectif)
 
 		siren := siret[0:9] // trim siret into a siren
+		_, alreadyDetected := detectedSirens[siren]
 
-		if shouldKeep && detectedSirens[siren] == false {
-			detectedSirens[siren] = true
+		if shouldKeep && alreadyDetected == false {
+			detectedSirens[siren] = struct{}{}
 			fmt.Fprintln(w, siren)
 		}
 	}

--- a/createfilter/main.go
+++ b/createfilter/main.go
@@ -75,7 +75,7 @@ func initializeEffectifReader(f *os.File) *csv.Reader {
 }
 
 func outputPerimeter(r *csv.Reader, w io.Writer, nbMois, minEffectif, nIgnoredCols int) {
-	perimeter := []string{}
+	detectedSirens := map[string]bool{}
 	_, err := r.Read() // en tête
 	if err != nil {
 		log.Panic(err)
@@ -89,15 +89,16 @@ func outputPerimeter(r *csv.Reader, w io.Writer, nbMois, minEffectif, nIgnoredCo
 		} else if err != nil {
 			log.Panic(err)
 		}
-		shouldKeep := len(record[1]) == 14 &&
+		siret := record[1]
+		shouldKeep := len(siret) == 14 &&
 			isInsidePerimeter(record[NbLeadingColsToSkip:len(record)-nIgnoredCols], nbMois, minEffectif)
 
-		if shouldKeep {
-			perimeter = append(perimeter, record[1])
+		siren := siret[0:9] // trim siret into a siren
+
+		if shouldKeep && detectedSirens[siren] == false {
+			detectedSirens[siren] = true
+			fmt.Fprintln(w, siren)
 		}
-	}
-	for _, siret := range perimeter {
-		fmt.Fprintln(w, siret[0:9])
 	}
 }
 

--- a/createfilter/main_test.go
+++ b/createfilter/main_test.go
@@ -65,6 +65,29 @@ func TestOutputPerimeter(t *testing.T) {
 		actualSirens := strings.Split(strings.TrimSpace(output.String()), "\n")
 		assert.Equal(t, expectedSirens, actualSirens)
 	})
+
+	t.Run("outputPerimeter ne doit pas contenir deux fois le même siren", func(t *testing.T) {
+		// setup conditions and expectations
+		minEffectif := 1
+		nbIgnoredCols := 0
+		expectedSirens := []string{"111111111", "333333333"}
+		effectifData := strings.Join([]string{
+			"compte;siret;rais_soc;ape_ins;dep;eff201011",
+			"111111111111111111;11111111111112;ENTREPRISE;1234Z;53;1", // premier établissement ayant 111111111 comme siren
+			"111111111111111111;11111111111113;ENTREPRISE;1234Z;92;1", // deuxième établissement ayant 111111111 comme siren
+			"333333333333333333;33333333333333;ENTREPRISE;1234Z;92;1",
+		}, "\n")
+		// run the test
+		var output bytes.Buffer
+		reader := csv.NewReader(strings.NewReader(effectifData))
+		reader.Comma = ';'
+		writer := bufio.NewWriter(&output)
+		outputPerimeter(reader, writer, DefaultNbMois, minEffectif, nbIgnoredCols)
+		writer.Flush()
+		// assert
+		actualSirens := strings.Split(strings.TrimSpace(output.String()), "\n")
+		assert.Equal(t, expectedSirens, actualSirens)
+	})
 }
 
 func TestDetectDateFinEffectif(t *testing.T) {


### PR DESCRIPTION
En investiguant des erreurs de parsing de `cotisations` (ce qui m'a fait remonter jusqu'au filtre de périmètre), je me suis rendu compte que notre dernier filtre contenait plusieurs fois le même SIREN !

Cette amélioration propose de dé-dupliquer les numéros SIREN en sortie de la création de périmètre.