### PR TITLE
fix: skip lines with empty siret during effectif filter

### DIFF
--- a/createfilter/main.go
+++ b/createfilter/main.go
@@ -109,7 +109,7 @@ func outputPerimeter(r *csv.Reader, w io.Writer, nbMois, minEffectif, nIgnoredCo
 		}
 	}
 	if skippedLines > 0 {
-		fmt.Printf("%d lines with bad siret/siren skipped :(", skippedLines)
+		fmt.Printf("%d lines with bad siret/siren skipped :( \n", skippedLines)
 	}
 
 }

--- a/createfilter/main.go
+++ b/createfilter/main.go
@@ -93,13 +93,18 @@ func outputPerimeter(r *csv.Reader, w io.Writer, nbMois, minEffectif, nIgnoredCo
 		shouldKeep := len(siret) == 14 &&
 			isInsidePerimeter(record[NbLeadingColsToSkip:len(record)-nIgnoredCols], nbMois, minEffectif)
 
-		siren := siret[0:9] // trim siret into a siren
-		_, alreadyDetected := detectedSirens[siren]
-
-		if shouldKeep && alreadyDetected == false {
-			detectedSirens[siren] = struct{}{}
-			fmt.Fprintln(w, siren)
+		var siren string
+		if len(siret) >= 9 {
+			siren = siret[0:9] // trim siret into a siren
+			_, alreadyDetected := detectedSirens[siren]
+			if shouldKeep && alreadyDetected == false {
+				detectedSirens[siren] = struct{}{}
+				fmt.Fprintln(w, siren)
+			}
+		} else {
+			fmt.Printf("%d digit siret encountered, skipping line", len(siret))
 		}
+
 	}
 }
 

--- a/createfilter/main.go
+++ b/createfilter/main.go
@@ -80,7 +80,9 @@ func outputPerimeter(r *csv.Reader, w io.Writer, nbMois, minEffectif, nIgnoredCo
 	if err != nil {
 		log.Panic(err)
 	}
+	lineNumber, skippedLines := 0, 0
 	for {
+		lineNumber++
 		record, err := r.Read()
 
 		// Stop at EOF.
@@ -102,10 +104,14 @@ func outputPerimeter(r *csv.Reader, w io.Writer, nbMois, minEffectif, nIgnoredCo
 				fmt.Fprintln(w, siren)
 			}
 		} else {
-			fmt.Printf("%d digit siret encountered, skipping line", len(siret))
+			skippedLines++
+			fmt.Printf("%d digit siret encountered, skipping line %d \n", len(siret), lineNumber)
 		}
-
 	}
+	if skippedLines > 0 {
+		fmt.Printf("%d lines with bad siret/siren skipped :(", skippedLines)
+	}
+
 }
 
 func isInsidePerimeter(record []string, nbMois, minEffectif int) bool {


### PR DESCRIPTION
Lors d'une intégration j'ai rencontré un fichier qui m'a provoqué l'erreur suivante:

```
/home/centos/prepare-import/prepare-import -batch 2101
Listing data files in 2101/ ...
Found effectif file: 083fe617e80f2e30a21598d38a854bc6
Generating filter file: /2101/filter_siren_2101.csv ...
panic: runtime error: slice bounds out of range [:9] with length 0

goroutine 1 [running]:
github.com/signaux-faibles/prepare-import/createfilter.outputPerimeter(0xc0000f6120, 0x56aac0, 0xc0000a8108, 0x64, 0xa, 0x3)
	/home/centos/prepare-import/createfilter/main.go:96 +0x3af
github.com/signaux-faibles/prepare-import/createfilter.CreateFilter(0x56aac0, 0xc0000a8108, 0xc0000a7290, 0x25, 0x64, 0xa, 0x2, 0x0, 0x0)
	/home/centos/prepare-import/createfilter/main.go:66 +0x14d
github.com/signaux-faibles/prepare-import/prepareimport.createFilterFromEffectif(0xc0000ca5a0, 0x1a, 0xc0000a7290, 0x25, 0x1a, 0x540410)
	/home/centos/prepare-import/prepareimport/prepareimport.go:124 +0x190
github.com/signaux-faibles/prepare-import/prepareimport.PrepareImport(0x540299, 0x1, 0x56bb40, 0xc0000825d0, 0x0, 0x0, 0x6d, 0xc0000825c0, 0x0)
	/home/centos/prepare-import/prepareimport/prepareimport.go:64 +0x1317
main.main()
	/home/centos/prepare-import/main.go:35 +0x206
```

Je vais signaler cette anomalie au fournisseur de donnée car cela n'a jamais été le cas avant et c'est peut être un signe anonciateur d'autres corruptions du fichier… Cela étant dit cette PR a pour objectif de permettre d'ignorer les lignes qui présentent un siret de moins de 9 caractères.