### PR TITLE
feat: Reconnaissance de l'extension .gz pour les fichiers urssaf

### DIFF
--- a/prepareimport/filetypes.go
+++ b/prepareimport/filetypes.go
@@ -6,22 +6,23 @@ import (
 
 // ExtractFileTypeFromFilename returns a file type from filename, or empty string for unsupported file names
 func ExtractFileTypeFromFilename(filename string) ValidFileType {
+	possiblyGzFilename := regexp.MustCompile(`^(.*)\.gz$`).ReplaceAllString(filename, `$1`)
 	switch {
 	case filename == "act_partielle_conso_depuis2014_FRANCE.csv":
 		return apconso
 	case filename == "act_partielle_ddes_depuis2015_FRANCE.csv":
 		return apdemande
-	case filename == "Sigfaible_etablissement_utf8.csv":
+	case possiblyGzFilename == "Sigfaible_etablissement_utf8.csv":
 		return adminUrssaf
-	case filename == "Sigfaible_effectif_siren.csv":
+	case possiblyGzFilename == "Sigfaible_effectif_siren.csv":
 		return effectifEnt
-	case filename == "Sigfaible_pcoll.csv":
+	case possiblyGzFilename == "Sigfaible_pcoll.csv":
 		return procol
-	case filename == "Sigfaible_cotisdues.csv":
+	case possiblyGzFilename == "Sigfaible_cotisdues.csv":
 		return cotisation
-	case filename == "Sigfaible_delais.csv":
+	case possiblyGzFilename == "Sigfaible_delais.csv":
 		return delai
-	case filename == "Sigfaible_ccsf.csv":
+	case possiblyGzFilename == "Sigfaible_ccsf.csv":
 		return ccsf
 	case filename == "sireneUL.csv":
 		return sireneUl

--- a/prepareimport/filetypes_test.go
+++ b/prepareimport/filetypes_test.go
@@ -23,6 +23,16 @@ func TestExtractFileTypeFromFilename(t *testing.T) {
 		{"Sigfaible_delais.csv", delai},
 		{"Sigfaible_ccsf.csv", ccsf},
 
+		// compressed version of urssaf files
+		{"Sigfaible_ccsf.csv.gz", ccsf},
+		{"Sigfaible_etablissement_utf8.csv.gz", adminUrssaf}, // sfdata parser name: "comptes"
+		{"Sigfaible_cotisdues.csv.gz", cotisation},
+		{"Sigfaible_debits.csv.gz", debit},
+		{"Sigfaible_delais.csv.gz", delai},
+		{"Sigfaible_effectif_siren.csv.gz", effectifEnt},
+		{"Sigfaible_effectif_siret.csv.gz", effectif},
+		{"Sigfaible_pcoll.csv.gz", procol},
+
 		// guessed from dgefp files
 		{"act_partielle_conso_depuis2014_FRANCE.csv", apconso},
 		{"act_partielle_ddes_depuis2015_FRANCE.csv", apdemande},


### PR DESCRIPTION
Suite de https://github.com/signaux-faibles/opensignauxfaibles/pull/310.