### PR TITLE
fix: Création de filtre à partir d'un fichier effectif compressé

### DIFF
--- a/createfilter/UrssafToPeriod.go
+++ b/createfilter/UrssafToPeriod.go
@@ -32,12 +32,12 @@ func UrssafToPeriod(urssaf string) (Periode, error) {
 	}
 
 	if len(urssaf) != 6 {
-		return period, errors.New("Valeur non autorisée")
+		return period, errors.New("valeur non autorisée")
 	}
 
 	year, err := strconv.Atoi(urssaf[0:4])
 	if err != nil {
-		return Periode{}, errors.New("Valeur non autorisée")
+		return Periode{}, errors.New("valeur non autorisée")
 	}
 
 	if urssaf[4:6] == "62" {

--- a/prepareimport/filesproperty.go
+++ b/prepareimport/filesproperty.go
@@ -87,6 +87,7 @@ type BatchFile interface {
 	BatchKey() BatchKey
 	Name() string
 	Path() string
+	AbsolutePath(parentDir string) string
 	GetGzippedSize() uint64     // in bytes
 	AddGzippedSize(size uint64) // in bytes
 }
@@ -113,11 +114,15 @@ func (file *batchFile) Name() string {
 }
 
 func (file *batchFile) Path() string {
+	return file.AbsolutePath("")
+}
+
+func (file *batchFile) AbsolutePath(parentDir string) string {
 	var prefix string
 	if file.gzippedSize > 0 {
 		prefix = "gzip:"
 	}
-	return prefix + file.batchKey.Path() + file.filename
+	return prefix + path.Join(parentDir, file.batchKey.Path(), file.filename)
 }
 
 func (file *batchFile) AddGzippedSize(size uint64) {

--- a/prepareimport/filesproperty.go
+++ b/prepareimport/filesproperty.go
@@ -113,10 +113,12 @@ func (file *batchFile) Name() string {
 	return file.filename
 }
 
+// AbsolutePath retourne le chemin relatif du fichier, avec un préfixe "gzip:" si celui-ci est compressé.
 func (file *batchFile) Path() string {
 	return file.AbsolutePath("")
 }
 
+// AbsolutePath retourne le chemin absolu du fichier, avec un préfixe "gzip:" si celui-ci est compressé.
 func (file *batchFile) AbsolutePath(parentDir string) string {
 	var prefix string
 	if file.gzippedSize > 0 {

--- a/prepareimport/prepareimport.go
+++ b/prepareimport/prepareimport.go
@@ -56,7 +56,7 @@ func PrepareImport(pathname string, batchKey BatchKey, providedDateFinEffectif s
 		if effectifFile == nil {
 			return nil, errors.New("filter is missing: batch should include a filter or one effectif file")
 		}
-		effectifFilePath := path.Join(pathname, effectifFile.Path())
+		effectifFilePath := effectifFile.AbsolutePath(pathname)
 		effectifBatch := effectifFile.BatchKey()
 		filterFile = newBatchFile(effectifBatch, "filter_siren_"+effectifBatch.String()+".csv")
 		println("Generating filter file: " + filterFile.Path() + " ...")

--- a/prepareimport/prepareimport.go
+++ b/prepareimport/prepareimport.go
@@ -138,10 +138,7 @@ func getBatchPath(pathname string, batchKey BatchKey) string {
 
 func fileExists(filename string) bool {
 	_, err := os.Stat(filename)
-	if os.IsNotExist(err) {
-		return false
-	}
-	return true
+	return !os.IsNotExist(err)
 }
 
 // Copy the src file to dst. Any existing file will be overwritten and will not

--- a/prepareimport/prepareimport.go
+++ b/prepareimport/prepareimport.go
@@ -84,7 +84,7 @@ func PrepareImport(pathname string, batchKey BatchKey, providedDateFinEffectif s
 
 	if effectifFile != nil {
 		println("Detecting dateFinEffectif from effectif file ...")
-		effectifFilePath := path.Join(pathname, effectifFile.Path())
+		effectifFilePath := effectifFile.AbsolutePath(pathname)
 		dateFinEffectif, err = createfilter.DetectDateFinEffectif(effectifFilePath, createfilter.DefaultNbIgnoredCols) // TODO: éviter de lire le fichier Effectif deux fois
 		if err != nil {
 			return nil, err

--- a/prepareimport/prepareimport_test.go
+++ b/prepareimport/prepareimport_test.go
@@ -271,7 +271,7 @@ func TestPrepareImport(t *testing.T) {
 			"719776012f6a124c3fab0f1c74fd585a":      {},
 			"719776012f6a124c3fab0f1c74fd585a.info": []byte(metadata),
 		})
-		adminObject, err := PrepareImport(dir, dummyBatchKey, "") // => open /var/folders/v3/_c06yg_96tbf9kzmm0zq0y180000gn/T/example424586267/gzip:/1802/719776012f6a124c3fab0f1c74fd585a: no such file or directory
+		adminObject, err := PrepareImport(dir, dummyBatchKey, "") // => open gzip:/var/folders/v3/_c06yg_96tbf9kzmm0zq0y180000gn/T/example695100756/1802/719776012f6a124c3fab0f1c74fd585a: no such file or directory
 		filterFileName := "filter_siren_" + dummyBatchKey.String() + ".csv"
 		expected := FilesProperty{
 			"effectif": {dummyBatchFile("Sigfaible_effectif_siret.csv.gz")},

--- a/prepareimport/prepareimport_test.go
+++ b/prepareimport/prepareimport_test.go
@@ -265,10 +265,13 @@ func TestPrepareImport(t *testing.T) {
 		// 	return file, nil, err
 		// }
 
+		metadata := `{ "MetaData": { "filename": "Sigfaible_effectif_siret.csv.gz", "goup-path": "acoss" }, "Size": 172391771 }`
 		dir := CreateTempFilesWithContent(t, dummyBatchKey, map[string][]byte{
-			"Sigfaible_effectif_siret.csv.gz": compressedEffectifData.Bytes(),
+			// "Sigfaible_effectif_siret.csv.gz": compressedEffectifData.Bytes(),
+			"719776012f6a124c3fab0f1c74fd585a":      {},
+			"719776012f6a124c3fab0f1c74fd585a.info": []byte(metadata),
 		})
-		adminObject, err := PrepareImport(dir, dummyBatchKey, "")
+		adminObject, err := PrepareImport(dir, dummyBatchKey, "") // => open /var/folders/v3/_c06yg_96tbf9kzmm0zq0y180000gn/T/example424586267/gzip:/1802/719776012f6a124c3fab0f1c74fd585a: no such file or directory
 		filterFileName := "filter_siren_" + dummyBatchKey.String() + ".csv"
 		expected := FilesProperty{
 			"effectif": {dummyBatchFile("Sigfaible_effectif_siret.csv.gz")},


### PR DESCRIPTION
## Problème

Lorsqu'on exécute `prepare-import` dans un répertoire dans lequel le fichier effectif est compressé, une erreur `open /somedir/gzip:/1802/719776012f6a124c3fab0f1c74fd585a: no such file or directory` empêche la création du filtre, causant une erreur d'importation dans `sfdata`: https://github.com/signaux-faibles/opensignauxfaibles/issues/354.

## Solution

- Assurer que le préfixe `gzip:` est toujours en début de chemin, même après constitution du chemin absolu.
- Étendre le support du préfixe `gzip:` à `createfilter`.

## Bonus

- Corrections d'avertissements de linter.
- Déduplication du code de certains tests.